### PR TITLE
DE2690 - Disabled outline buttons

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -4,12 +4,13 @@
   &.btn-outline {
     border-width: 2px;
     color: $border;
-    background: $cr-white;
+    background: $btn-outline-bg;
     &:focus {
       color: $border;
+      background: $btn-outline-bg;
     }
     &:hover {
-      background: $cr-gray-lighter;
+      background: $btn-outline-hover-bg;
     }
   }
 }

--- a/assets/stylesheets/_overrides.scss
+++ b/assets/stylesheets/_overrides.scss
@@ -49,6 +49,8 @@ $btn-gray-color: $cr-white;
 $btn-option-color: $cr-white;
 $btn-option-bg: $cr-gray;
 $btn-option-border: $cr-gray;
+$btn-outline-bg: $cr-white;
+$btn-outline-hover-bg: $cr-gray-lighter;
 
 // Forms
 $input-bg: $cr-gray-lighter !default;

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -35,13 +35,15 @@
     &:active {
       background: $cr-teal;
       border-color: $cr-teal;
-      &:hover {
-        background: $cr-teal;
-        border-color: $cr-teal;
-      }
+      color: $cr-white;
     }
     &.btn-outline {
+      &:hover {
+        background: $cr-white;
+      }
       &:focus {
+        background: $cr-teal;
+        border-color: $cr-teal;
         color: $cr-white;
       }
     }
@@ -154,11 +156,21 @@ a {
   }
 }
 
-.btn {
+.btn-option {
   &.btn-outline {
     &.disabled {
       &:hover {
-        background: $cr-white;
+        background: $btn-outline-hover-bg;
+        border-color: $cr-gray;
+      }
+      &:focus {
+        background: $btn-outline-bg;
+        border-color: $btn-option-border;
+        color: inherit;
+      }
+      &:focus:hover {
+        background: $btn-outline-hover-bg;
+        color: $cr-gray;
       }
     }
   }


### PR DESCRIPTION
Fix disabled outline buttons so they don't turn a solid color on :focus.

>Disabled Outline Buttons turn solid after click and hover OFF