### PR TITLE
Defect/de2693 buttons not highlighted in ff safari mobile

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -1,5 +1,9 @@
 @mixin crds-button-variant($color, $background, $border) {
   @include button-variant($color, $background, $border);
+  &.active,
+  &:active {
+    background: $background;
+  }
 
   &.btn-outline {
     border-width: 2px;

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -114,43 +114,25 @@
       color: $cr-teal;
     }
 
-    &:focus {
-      &:hover {
-        background: $cr-teal;
-        border-color: $cr-teal;
-        color: $cr-white;
-      }
-    }
-
-    &:active {
-      box-shadow: none;
-    }
-  }
-}
-
-
-.btn-option {
-  &.btn-teal {
-    border: 2px solid $cr-teal;
-    background: $cr-white;
-    color: $cr-teal;
-
-    &:hover {
-      background: $cr-white;
+    &:focus:hover {
+      background: $cr-teal;
       border-color: $cr-teal;
-      color: $cr-teal;
+      color: $cr-white;
     }
 
-    &:focus {
+    &.active,
+    &:active {
+      background: $cr-teal;
+      border-color: $cr-teal;
+      box-shadow: none;
+      color: $cr-white;
+
+      &:focus,
       &:hover {
         background: $cr-teal;
         border-color: $cr-teal;
         color: $cr-white;
       }
-    }
-
-    &:active {
-      box-shadow: none;
     }
   }
 }

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -38,13 +38,21 @@
       color: $cr-white;
     }
     &.btn-outline {
-      &:hover {
-        background: $cr-white;
-      }
+      &.active,
+      &:active,
       &:focus {
         background: $cr-teal;
         border-color: $cr-teal;
+        box-shadow: none;
         color: $cr-white;
+        outline: none;
+
+        &:hover {
+          background: $cr-teal;
+        }
+      }
+      &:hover {
+        background: $cr-white;
       }
     }
   }


### PR DESCRIPTION
>https://design-int.crossroads.net/ui/buttons/groups
If I click on a button in the DDK Button section in Edge and Chrome, they remain highlighted/selected.  This effect is not in place in Safari, Firefox, and mobile.

I added styles targeting `.active` (turns buttons in button groups teal when clicked).