### PR TITLE
DE2711 - No outline button group

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -13,4 +13,26 @@
       background: $btn-outline-hover-bg;
     }
   }
+  &.btn-no-outline {
+    border-width: 2px;
+    border-color: $btn-outline-bg;
+    color: $border;
+    background: $btn-outline-bg;
+    .active,
+    &:active,
+    &:focus {
+      color: $cr-white;
+      background: $background;
+      border-color: $background;
+      box-shadow: none;
+    }
+    &:focus:hover {
+      border-color: $border;
+      background: $background;
+      color: $color;
+    }
+    &:hover {
+      background: $cr-white;
+    }
+  }
 }

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -47,6 +47,26 @@
         color: $cr-white;
       }
     }
+    &.btn-no-outline {
+      border-color: $cr-white;
+      background: $cr-white;
+      color: $btn-option-border;
+      &:hover {
+        background: $cr-white;
+        border-color: $cr-white;
+      }
+      .active,
+      &:active,
+      &:focus {
+        background: $cr-teal;
+        border-color: $cr-teal;
+        color: $cr-white;
+      }
+      &:focus:hover {
+        background: $cr-teal;
+        border-color: $cr-teal;
+      }
+    }
   }
   &.btn-default {
     @include crds-button-variant($btn-default-color, $btn-default-bg, $btn-default-border);


### PR DESCRIPTION
>In-line giving has a button group pattern that shows buttons without an outline, once selected, they have a background. That needs to be a pattern in the DDK.

Add styles for buttons without a border. Applicable to all button styles.