### PR TITLE
Defect/de2711 de2693 button fixes

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -3,38 +3,51 @@
   &.active,
   &:active {
     background: $background;
+    box-shadow: none;
   }
 
   &.btn-outline {
+    background: $btn-outline-bg;
     border-width: 2px;
     color: $border;
-    background: $btn-outline-bg;
+
+    .active,
+    &:active,
     &:focus {
-      color: $border;
       background: $btn-outline-bg;
+      color: $border;
+
+      &:hover {
+        color: $border;
+      }
     }
+
     &:hover {
       background: $btn-outline-hover-bg;
     }
   }
+
   &.btn-no-outline {
-    border-width: 2px;
-    border-color: $btn-outline-bg;
-    color: $border;
     background: $btn-outline-bg;
+    border-color: $btn-outline-bg;
+    border-width: 2px;
+    color: $border;
+
     .active,
     &:active,
     &:focus {
-      color: $cr-white;
       background: $background;
       border-color: $background;
       box-shadow: none;
+      color: $cr-white;
     }
+
     &:focus:hover {
-      border-color: $border;
       background: $background;
+      border-color: $border;
       color: $color;
     }
+
     &:hover {
       background: $cr-white;
     }

--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -13,4 +13,26 @@
       background: $btn-outline-hover-bg;
     }
   }
+  &.btn-no-outline {
+    border-width: 2px;
+    border-color: $btn-outline-bg;
+    color: $border;
+    background: $btn-outline-bg;
+    .active,
+    &:active,
+    &:focus {
+      color: $cr-white;
+      background: $background;
+      border-color: $background;
+      box-shadow: none;
+    }
+    &:focus:hover {
+      border-color: $border;
+      background: $background;
+      color: $color;
+    }
+    &:hover {
+      background: $cr-white;
+    }
+  }
 }

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -1,8 +1,14 @@
 .btn {
   border-radius: $btn-border-radius-base;
 
-  &:focus,
-  &:active:focus {
+  &.active,
+  &:active {
+    &:focus {
+      outline: none;
+    }
+  }
+
+  &:focus {
     box-shadow: none;
     outline: none;
   }

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -47,6 +47,26 @@
         color: $cr-white;
       }
     }
+    &.btn-no-outline {
+      border-color: $cr-white;
+      background: $cr-white;
+      color: $btn-option-border;
+      &:hover {
+        background: $cr-white;
+        border-color: $cr-white;
+      }
+      .active,
+      &:active,
+      &:focus {
+        background: $cr-teal;
+        border-color: $cr-teal;
+        color: $cr-white;
+      }
+      &:focus:hover {
+        background: $cr-teal;
+        border-color: $cr-teal;
+      }
+    }
   }
   &.btn-default {
     @include crds-button-variant($btn-default-color, $btn-default-bg, $btn-default-border);

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -49,6 +49,7 @@
 
         &:hover {
           background: $cr-teal;
+          color: $cr-white;
         }
       }
       &:hover {
@@ -57,18 +58,22 @@
     }
     &.btn-no-outline {
       border-color: $cr-white;
-      background: $cr-white;
-      color: $btn-option-border;
+      background: $btn-option-color;
+      color: $btn-option-bg;
       &:hover {
         background: $cr-white;
         border-color: $cr-white;
       }
-      .active,
+      &.active,
       &:active,
       &:focus {
         background: $cr-teal;
         border-color: $cr-teal;
         color: $cr-white;
+
+        &:hover {
+          color: $btn-option-color;
+        }
       }
       &:focus:hover {
         background: $cr-teal;
@@ -166,21 +171,23 @@ a {
   }
 }
 
-.btn-option {
+.btn {
   &.btn-outline {
     &.disabled {
       &:hover {
-        background: $btn-outline-hover-bg;
-        border-color: $cr-gray;
+        background: $cr-white;
       }
-      &:focus {
-        background: $btn-outline-bg;
-        border-color: $btn-option-border;
-        color: inherit;
-      }
-      &:focus:hover {
-        background: $btn-outline-hover-bg;
-        color: $cr-gray;
+    }
+
+    &.btn-option {
+      &.disabled {
+        &:active,
+        &:focus,
+        &:hover {
+          background: $btn-option-color;
+          border-color: $btn-option-border;
+          color: $btn-option-bg;
+        }
       }
     }
   }


### PR DESCRIPTION
Update outlined button hover states so text doesn't turn white.
Remove `:focus` blue outline from buttons.
Remove hover state on disabled outlined buttons