### PR TITLE
DE2719 - Button Toggle Group

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -162,14 +162,10 @@
       color: $cr-teal;
     }
 
+    &.active,
+    &:active,
     &:focus:hover {
       background: $cr-teal;
-      border-color: $cr-teal;
-      color: $cr-white;
-    }
-
-    &.active,
-    &:active {
       border-color: $cr-teal;
       box-shadow: none;
       color: $cr-white;


### PR DESCRIPTION
Fix active state on toggle button group. Currently defaults to gray and must be teal.

Corresponds to crds-styleguide: `development`