### PR TITLE
DE2729 - Scaling Button Text

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -206,6 +206,10 @@ a {
   display: flex;
   flex-flow: column nowrap;
 
+  &[type="submit"] {
+    font-size: .875rem;
+  }
+
   .btn-flex {
     flex: 1 1 auto;
     min-height: 3.5rem;


### PR DESCRIPTION
> Not all Block button text does not scale up when iphone is rotated

Corresponds with branch `crds-styleguide: development`