### PR TITLE
DE2729 - Scaling button text

### DIFF
--- a/assets/stylesheets/base/_global.scss
+++ b/assets/stylesheets/base/_global.scss
@@ -6,6 +6,11 @@
   outline: 0;
 }
 
+html {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   font-size: $base-font-size;
   @extend .font-family-base;


### PR DESCRIPTION
Add CSS to prevent text from jumping up in size.

Should correspond with `crds-styleguide/development`