### PR TITLE
DE2762 - Dark theme text

### DIFF
--- a/assets/stylesheets/components/_headings.scss
+++ b/assets/stylesheets/components/_headings.scss
@@ -38,6 +38,10 @@ h4 {
   @media screen and (min-width: $screen-xs) {
     font-size: 1.5rem; // 24px
   }
+
+  .dark-theme & {
+    border-top: 1px solid $cr-gray-dark;
+  }
 }
 
 h5 {
@@ -62,4 +66,17 @@ h6 {
   font-size: .75rem; // 12px
   font-weight: bold;
   text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  .dark-theme & {
+    $headings-color: $cr-gray-dark;
+
+    color: $headings-color;
+  }
 }

--- a/assets/stylesheets/themes/_dark.scss
+++ b/assets/stylesheets/themes/_dark.scss
@@ -2,16 +2,11 @@
   $body-bg: $cr-black;
   $text-color: $cr-gray;
   $hr-border: $cr-gray-darker;
-  $headings-color: $cr-gray-dark;
 
   background: $body-bg;
   color: $text-color;
 
   hr {
     border-top-color: $hr-border;
-  }
-
-  h2 {
-    color: $headings-color;
   }
 }


### PR DESCRIPTION
> When in dark mode, the text for several headings are hard to read on the black background. 

Corresponds with `crds-styleguide/development`