### PR TITLE
US6542 - Add links to typesetting

### DIFF
--- a/assets/stylesheets/_overrides.scss
+++ b/assets/stylesheets/_overrides.scss
@@ -17,6 +17,8 @@ $bootstrap-sass-asset-helper: true;
 // Scaffolding
   $body-bg: $cr-white;
   $text-color: $cr-gray-dark !default;
+  $link-color: $cr-cyan !default;
+  $link-color-hover: $cr-cyan-dark !default;
   $link-hover-decoration: underline;
 
 // Typography

--- a/assets/stylesheets/components/_typography.scss
+++ b/assets/stylesheets/components/_typography.scss
@@ -142,3 +142,15 @@ dl.crds-list {
     }
   }
 }
+
+/* Links */
+
+a {
+  &.secondary {
+    color: $cr-gray;
+
+    &:hover {
+      color: $cr-gray-dark;
+    }
+  }
+}


### PR DESCRIPTION
> Add colors for links (primary, secondary, etc)
Include when to use what type of link

_Note: This story uses the class `font-size-small` defined in US6466._

Corresponds with crdschurch/crds-styleguide#45