### PR TITLE
US6263 - Forms

### DIFF
--- a/assets/stylesheets/components/_form-validation.scss
+++ b/assets/stylesheets/components/_form-validation.scss
@@ -21,17 +21,17 @@
     background: $cr-white;
     box-shadow: none;
 
-    &.ng-invalid,
+    &.ng-touched.ng-invalid,
     &.ng-valid {
       border-right-style: solid;
       border-right-width: 8px;
     }
 
-    &.ng-valid {
+    &.ng-touched {
       border-right-color: $brand-success;
     }
 
-    &.ng-invalid {
+    &.ng-touched.ng-invalid {
       border-right-color: $brand-danger;
     }
   }


### PR DESCRIPTION
@tcmacdonald I added `.ng-touched` to the form validation styles. Form fields should only validate once user has interacted with that field.

Corresponds with crds-styleguide/feature/US6263-forms