### PR TITLE
DE2817 - Valid Form State

### DIFF
--- a/assets/stylesheets/components/_form-validation.scss
+++ b/assets/stylesheets/components/_form-validation.scss
@@ -21,19 +21,22 @@
     background: $cr-white;
     box-shadow: none;
 
-    &.ng-touched.ng-invalid,
-    &.ng-valid {
-      border-right-style: solid;
-      border-right-width: 8px;
-    }
-
     &.ng-touched {
-      border-right-color: $brand-success;
+      &.ng-invalid,
+      &.ng-valid {
+        border-right-style: solid;
+        border-right-width: 8px;
+      }
+
+      &.ng-valid {
+        border-right-color: $brand-success;
+      }
+
+      &.ng-invalid {
+        border-right-color: $brand-danger;
+      }
     }
 
-    &.ng-touched.ng-invalid {
-      border-right-color: $brand-danger;
-    }
   }
 
   &.has-success {


### PR DESCRIPTION
Fix valid input field - border-right should stay green when blue border focus applied to input.

Corresponds with `crds-styleguide/development`

