### PR TITLE
Feature/us6263 forms

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -27,8 +27,7 @@
 }
 
 .checkbox {
-  input[type="checkbox"],
-  input[type="radio"] {
+  input[type="checkbox"] {
     &:focus {
       box-shadow: inset 0 0 0 2px $input-border-focus;
     }
@@ -40,8 +39,13 @@
       width: 16px;
       height: 16px;
       outline: none;
-      outline-offset: none;
     }
+  }
+}
+
+.check {
+  &:focus {
+    box-shadow: 0 0 0 2px $input-border-focus;
   }
 }
 

--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -30,8 +30,6 @@
   input[type="checkbox"],
   input[type="radio"] {
     &:focus {
-      // background: $input-bg-focus;
-      // border-color: $input-border-focus;
       box-shadow: inset 0 0 0 2px $input-border-focus;
     }
   }
@@ -172,13 +170,66 @@ input[type="checkbox"]:disabled {
 
 .radio-inline {
   margin-top: 0;
-  padding-left: 10px;
+  padding-left: 0;
+}
 
-  &:first-child {
-    padding-left: 0;
+.radio {
+  input[type=radio] {
+    position: absolute;
+    visibility: hidden;
+    display: none;
+
+    &:checked {
+      ~ .check {
+        border: 2px solid $cr-cyan;
+        background: $cr-cyan;
+
+        &::before {
+          background: $cr-white;
+        }
+      }
+    }
   }
 
-  &:first-of-type {
-    padding-left: 0;
+  label {
+    display: block;
+    position: relative;
+    font-size: 14px;
+    padding: 8px 2px 17px 43px;
+    padding: 0 8px 0 25px;
+    margin: 0 auto;
+    height: 22px;
+    z-index: 9;
+    cursor: pointer;
+  }
+
+  .check {
+    display: block;
+    position: absolute;
+    border: 2px solid #979797;
+    border-radius: 100%;
+    height: 15px;
+    width: 15px;
+    top: 3px;
+    left: 5px;
+    z-index: 5;
+
+    &::before {
+      display: block;
+      position: absolute;
+      content: '';
+      border-radius: 100%;
+      height: 5px;
+      width: 5px;
+      top: 3px;
+      left: 3px;
+      margin: auto;
+    }
+  }
+
+  &.disabled {
+    .check {
+      background: #979797;
+    }
   }
 }

--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -26,6 +26,27 @@
   }
 }
 
+.checkbox {
+  input[type="checkbox"],
+  input[type="radio"] {
+    &:focus {
+      // background: $input-bg-focus;
+      // border-color: $input-border-focus;
+      box-shadow: inset 0 0 0 2px $input-border-focus;
+    }
+  }
+  input[type="checkbox"] {
+    &:focus {
+      border-radius: $border-radius-base;
+      box-shadow: inset 0 0 0 2px $input-border-focus;
+      width: 16px;
+      height: 16px;
+      outline: none;
+      outline-offset: none;
+    }
+  }
+}
+
 .form-control {
   border: none;
   border-radius: $input-border-radius;

--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -28,24 +28,14 @@
 
 .checkbox {
   input[type="checkbox"] {
-    &:focus {
-      box-shadow: inset 0 0 0 2px $input-border-focus;
-    }
-  }
-  input[type="checkbox"] {
+    height: 16px;
+    width: 16px;
+
     &:focus {
       border-radius: $border-radius-base;
       box-shadow: inset 0 0 0 2px $input-border-focus;
-      width: 16px;
-      height: 16px;
       outline: none;
     }
-  }
-}
-
-.check {
-  &:focus {
-    box-shadow: 0 0 0 2px $input-border-focus;
   }
 }
 
@@ -228,6 +218,10 @@ input[type="checkbox"]:disabled {
       top: 3px;
       left: 3px;
       margin: auto;
+    }
+
+    &:focus {
+      box-shadow: 0 0 0 2px $input-border-focus;
     }
   }
 


### PR DESCRIPTION
@tcmacdonald Brian asked that the focus state on radio buttons and checkboxes be consistent with the focus state seen on text input fields.

Also changed the radio buttons to reflect the markup/styles currently used on embed (makes radios look consistent on mobile **and** desktop screens).

Corresponds with crdschurch/crds-styleguide#56