### PR TITLE
DE2875 - Disabled btn hover effect

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -92,6 +92,17 @@
             background: $cr-teal;
           }
         }
+
+        &.disabled {
+          &.active,
+          &:active,
+          &:focus {
+            &,
+            &:hover{
+              background: transparent;
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
> Block Button "Option" type stays highlighted when clicked

Fixed a bug that occurs when a button has both `disabled` and `.btn-outline` classes. Bug is that these buttons turn teal when clicked and they should be transparent.

Corresponds with the development branches of crds-embed and crds-styleguide.