### PR TITLE
Defect/de2883 outline buttons

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -1,3 +1,10 @@
+@function tint($color, $percentage) {
+  @return mix(white, $color, $percentage);
+}
+@function shade($color, $percentage) {
+  @return mix(black, $color, $percentage);
+}
+
 @mixin crds-bg-variant($background, $color: $cr-white) {
   background-color: $background;
   color: $color;
@@ -5,10 +12,11 @@
 
 @mixin crds-button-variant($color, $background, $border) {
   @include button-variant($color, $background, $border);
+
+// solid buttons
   &.active,
   &:active {
     background: $background;
-    box-shadow: none;
   }
 
   &.disabled {
@@ -20,41 +28,79 @@
     &:active,
     &:focus,
     &:hover {
-      background: lighten($background, 25);
+      &, &:focus, &:hover {
+        background: lighten($background, 25);
+      }
     }
   }
 
+// outline buttons
   &.btn-outline {
+    background: transparent;
+    border-style: solid;
     border-width: 1px;
-    background: $btn-outline-bg;
     color: $border;
 
-    .active,
+    &.active,
     &:active,
     &:focus {
-      background: $btn-outline-bg;
-      color: $border;
-
-      &:hover {
+      &, &:hover {
+        background: rgba(tint(desaturate($border, 75), 95%), 0.75);
+        border-color: $border;
         color: $border;
+
+        .dark-theme & {
+          background: rgba(shade(desaturate($border, 75), 95%), 0.75);
+          border-color: rgba($border, 0.75);
+        }
       }
+
     }
 
     &:hover {
-      background: $btn-outline-hover-bg;
+      background: rgba(tint(desaturate($border, 75), 90%), 0.75);
+
+      .dark-theme & {
+        background: rgba(shade(desaturate($border, 75), 90%), 0.75);
+      }
     }
+
     &.disabled {
-      border: 1px solid lighten($border, 25);
+      background: transparent;
+      border-color: lighten($border, 25);
       color: lighten($border, 25);
 
       &.active,
       &:active,
       &:focus,
       &:hover {
-        background: $cr-white;
-        border: 1px solid lighten($border, 25);
-        color: lighten($border, 25);
+        &, &:hover {
+          background: transparent;
+          border-color: lighten($border, 25);
+          color: lighten($border, 25);
+
+          .dark-theme & {
+            background: transparent;
+            border-color: lighten($border, 25);
+            color: lighten($border, 25);
+          }
+        }
       }
+    }
+  }
+
+// link buttons
+  &.btn-link {
+    background: none;
+    border: none;
+    color: $background;
+    text-decoration: none;
+
+    &.active,
+    &:active,
+    &:focus {
+      background: $background;
+      color: $cr-white;
     }
   }
 }

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -76,8 +76,6 @@
 
   // link buttons
     &.btn-link {
-      border: 2px solid transparent;
-
       &.active,
       &:active,
       &:focus {
@@ -86,7 +84,7 @@
       }
 
       &:focus {
-        border-color: $input-border-focus;
+        box-shadow: 0 0 0 2px $input-border-focus inset;
       }
     }
   }

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -4,15 +4,12 @@
   margin-bottom: 5px;
 
   &.active,
-  &:active {
-    &:focus {
+  &:active,
+  &:focus {
+    &, &:focus {
+      box-shadow: none;
       outline: none;
     }
-  }
-
-  &:focus {
-    box-shadow: none;
-    outline: none;
   }
 
   &.btn-lg {
@@ -34,11 +31,6 @@
 
     .dark-theme & {
       @extend .btn-secondary;
-      &.btn-link,
-      &.btn-link:hover,
-      &.btn-link:focus {
-        background: none;
-      }
     }
   }
   &.btn-secondary {
@@ -47,118 +39,73 @@
   &.btn-gray {
     @include crds-button-variant($btn-gray-color, $btn-gray-bg, $btn-gray-border);
   }
-  &.btn-link {
-    color: $cr-gray;
-    &,
-    &:hover,
-    &:focus {
-      border: none;
-      background: none;
-      text-decoration: none;
-    }
-    &.btn-primary {
-      color: $btn-primary-bg;
-    }
-    &.btn-secondary {
-      color: $btn-secondary-bg;
-    }
-    &.btn-gray {
-      color: $btn-gray-bg;
-    }
-  }
   &.btn-option {
     @include crds-button-variant($btn-option-color, $btn-option-bg, $btn-option-border);
 
     font-weight: 500;
 
-    &:focus,
-    &:active {
-      background: $cr-teal;
-      border-color: $cr-teal;
-      color: $cr-white;
-    }
-
-    &.btn-link {
-      background: none;
-      color: $cr-gray;
-      &:focus {
-        background: none;
-        border-color: $input-border-focus;
-        box-shadow: inset 0 0 0 2px rgba($input-border-focus, 0.5);
-      }
-      &:active,
-      &.active {
+  // solid buttons
+    &.active,
+    &:active,
+    &:focus {
+      &, &:focus {
         background: $cr-teal;
         border-color: $cr-teal;
         color: $cr-white;
-        &:focus {
-          box-shadow: none;
-        }
       }
     }
 
+  // outline buttons
     &.btn-outline {
       &.active,
       &:active,
       &:focus {
-        background: $cr-teal;
-        border-color: $cr-teal;
-        box-shadow: none;
-        color: $cr-white;
-        outline: none;
-
-        &:hover {
+        &, &:hover {
           background: $cr-teal;
+          border-color: $cr-teal;
           color: $cr-white;
-        }
-      }
-      &:hover {
-        background: $cr-white;
-      }
-      &.disabled {
-        &.active,
-        &:active,
-        &:focus {
-          background: $cr-white;
-          border-color: lighten($btn-option-border, 25);
-          color: lighten($btn-option-border, 25);
-        }
-      }
-      .dark-theme & {
-        background: transparent;
 
-        &.active,
-        &:active,
-        &:focus {
-          &,
-          &:hover{
+          .dark-theme & {
             background: $cr-teal;
-          }
-        }
-
-        &.disabled {
-          border-color: rgba($cr-gray-light, 0.75);
-          color: rgba($cr-gray-light, 0.75);
-
-          &.active,
-          &:active,
-          &:focus,
-          &:hover {
-            &,
-            &:hover{
-              background: transparent;
-            }
+            border-color: $cr-teal;
+            color: $cr-white;
           }
         }
       }
+
+      // &.disabled {
+      //   &.active,
+      //   &:active,
+      //   &:focus {
+      //     &, &:focus {
+      //       background: transparent;
+
+      //       // .dark-theme & {
+      //       //   background: transparent;
+      //       //   border-color: lighten($border, 25);
+      //       //   color: lighten($border, 25);
+      //       // }
+      //     }
+      //   }
+      // }
+    }
+
+  // link buttons
+    &.btn-link {
+      &.active,
+      &:active,
+      &:focus {
+        background: $cr-teal;
+        color: $cr-white;
+      }
+
+      // &:focus {
+      //   border: 2px solid $input-border-focus;
+      // }
     }
   }
   &.btn-default {
     @include crds-button-variant($btn-default-color, $btn-default-bg, $btn-default-border);
-    &.btn-link {
-      background: none;
-      color: $btn-default-bg;
-    }
   }
 }
 

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -72,26 +72,12 @@
           }
         }
       }
-
-      // &.disabled {
-      //   &.active,
-      //   &:active,
-      //   &:focus {
-      //     &, &:focus {
-      //       background: transparent;
-
-      //       // .dark-theme & {
-      //       //   background: transparent;
-      //       //   border-color: lighten($border, 25);
-      //       //   color: lighten($border, 25);
-      //       // }
-      //     }
-      //   }
-      // }
     }
 
   // link buttons
     &.btn-link {
+      border: 2px solid transparent;
+
       &.active,
       &:active,
       &:focus {
@@ -99,9 +85,9 @@
         color: $cr-white;
       }
 
-      // &:focus {
-      //   border: 2px solid $input-border-focus;
-      // }
+      &:focus {
+        border-color: $input-border-focus;
+      }
     }
   }
   &.btn-default {


### PR DESCRIPTION
> Outline buttons are filled with Light color when in darkmode

On the dark-theme, all outlined buttons should have a dark background and not a white/light one. Previous fix only applied to `.btn-option` button types.

Corresponds to the development branch of crds-styleguide