### PR TITLE
Defect/de2897 input lg

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -46,6 +46,10 @@
   }
 }
 
+.input-lg {
+  height: 42px;
+}
+
 .help-block {
   @extend .font-family-accent;
 

--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -1,7 +1,6 @@
 // Text fields
 .form-group {
   input {
-    height: $input-height-base;
     padding: 0 12px;
   }
 


### PR DESCRIPTION
> It looks like the way we've overwritten the default bootrap inputs causes "input-lg" class to not work.
The amount field should be larger (to match prod design) in embed once the above issue is resolved.

Corresponds with crdschurch/crds-styleguide#66
Corresponds with crdschurch/crds-embed#255