### PR TITLE
DE2895 - Invoke error states

### DIFF
--- a/assets/stylesheets/components/_form-states.scss
+++ b/assets/stylesheets/components/_form-states.scss
@@ -5,7 +5,6 @@
     &, .dark-theme & {
       &, &.ng-touched.ng-invalid {
         &:focus {
-          background: $input-bg-focus;
           border-color: $input-border-focus;
           box-shadow: inset 0 0 0 1px rgba($input-border-focus, 0.5);
         }
@@ -51,7 +50,6 @@ select {
   &.form-control {
     &, .dark-theme & {
       &:focus {
-        background: $input-bg-focus;
         border-color: $input-border-focus;
         box-shadow: inset 0 0 0 1px rgba($input-border-focus, 0.5);
       }
@@ -64,27 +62,29 @@ input,
 text-area {
   &.form-control {
     &, .dark-theme & {
-      &.ng-touched.ng-invalid {
-        border: 1px solid $alert-danger;
-      }
-
-      &.ng-touched.ng-dirty {
-        border: 1px solid lighten($cr-gray, 35.25);
-        border-right: none;
-        background: $cr-white;
-
+      &.ng-touched {
         &.ng-invalid,
         &.ng-valid {
-          border-right-style: solid;
-          border-right-width: 6px;
+          border-style: solid;
+          border-width: 1px;
         }
 
         &.ng-invalid {
-          border-right-color: $alert-danger;
+          border-color: $alert-danger;
+
+          &:focus {
+            border-color: $alert-danger;
+            box-shadow: inset 0 0 0 1px rgba($alert-danger, 0.5);
+          }
         }
 
         &.ng-valid {
-          border-right-color: $alert-success;
+          border-color: $alert-success;
+
+          &:focus {
+            border-color: $alert-success;
+            box-shadow: inset 0 0 0 1px rgba($alert-success, 0.5);
+          }
         }
       }
     }


### PR DESCRIPTION
Addressing Brian's concerns on form field validation:
1. Implement valid/invalid `:focus` state, see Bootstrap [example](http://getbootstrap.com/css/#forms-control-validation)
2. Simplify invalid state
3. Validation should mimic embed in that it checks the input once a user clicks off the field

Walk-thru on embed's validation:
![embed-validation](https://cloud.githubusercontent.com/assets/5159392/23630451/246ca280-0289-11e7-8009-4feda69f6c38.gif)

Refactored DDK validation styles (removing thicker right-border and adding colored `:focus`)
![updated-validation](https://cloud.githubusercontent.com/assets/5159392/23630499/537c73b6-0289-11e7-86d6-cde4c4a551a3.gif)

Corresponds with crdschurch/crds-styleguide#67