### PR TITLE
DE2918 - Datepicker chevron colors

### DIFF
--- a/assets/stylesheets/svg/_sprite.scss
+++ b/assets/stylesheets/svg/_sprite.scss
@@ -20,6 +20,7 @@
 
 	.dark-theme & {
 		filter: invert(75%);
+		-webkit-filter: invert(75%);
 	}
 }
 

--- a/assets/template/css/_sprite.mustache
+++ b/assets/template/css/_sprite.mustache
@@ -28,6 +28,7 @@
 
 	.dark-theme & {
 		filter: invert(75%);
+		-webkit-filter: invert(75%);
 	}
 }
 


### PR DESCRIPTION
in iOS 9.0 the arrows in the calendar view are black instead of the expected white

https://int.crossroads.net/live/stream/?debug=true > get to the fund page and click on a fund that allows recurring giving, select weekly or monthly => arrows are black

(iOS 10 seems to be ok)

Corresponds with the development branches of other repos.