### PR TITLE
US7289 Publish NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-svg-icons": "./bin/build-svg-icons.js src/assets/svgs assets/svgs/icons.svg",
     "build-svg": "npm run build-css-icons && npm run build-svg-icons",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rimraf dist && npm run build-svg && webpack --config config/webpack.js  --progress --profile --bail"
+    "build": "rimraf dist && webpack --config config/webpack.js  --progress --profile --bail"
   },
   "files": [
     "assets"


### PR DESCRIPTION
Do not rebuild SVG in main build script; SVGs should be processed manually and the compiled output should be committed to the repo.