### PR TITLE
DE3138 - Toast Notification iOS

### DIFF
--- a/assets/stylesheets/components/_toast.scss
+++ b/assets/stylesheets/components/_toast.scss
@@ -1,5 +1,5 @@
 #toast-container {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -20,6 +20,7 @@
     height: 4rem;
     margin: 0;
     padding: 1.5rem 1rem;
+    transform: translate3d(0,0,0);
     border: none;
     color: $cr-white;
     background-image: none !important;

--- a/assets/stylesheets/components/_toast.scss
+++ b/assets/stylesheets/components/_toast.scss
@@ -1,9 +1,17 @@
 #toast-container {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 6;
+  z-index: 999;
+
+  .toast-title {
+    display: inline-block;
+    margin-right: 0.5rem;
+    & + div {
+      display: inline-block;
+    }
+  }
 
   > div.toast,
   > div.toast.toast-custom {


### PR DESCRIPTION
when i get a toaster notification (when i try to join a gathering i have already requested to join), and I am on a plus iOS device, that has 2 or more tabs open, and i am in landscape mode, the notification does not show.

It has something to do with the landscape and tabs. when i go down to only 1 tab, it does show.

---

This also addresses the title being inline with the message.