### PR TITLE
US7369 - Input Group Button

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -94,6 +94,9 @@ textarea {
   }
 
   .input-group-btn {
+    input, .btn {
+      height: 42px;
+    }
     .btn {
       padding-top: 11px;
       padding-bottom: 11px;

--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -94,9 +94,10 @@ textarea {
   }
 
   .input-group-btn {
-    button {
-      padding-top: 12px;
-      padding-bottom: 7px;
+    .btn {
+      padding-top: 11px;
+      padding-bottom: 11px;
+      line-height: 16px;
     }
   }
 }


### PR DESCRIPTION
As a designer/developer, I want to see guidance for input-group-btn in the DDK & crds-styles. 

Note: Ties to crdschurch/crds-styleguide#94

---

Made this change to account for text being in the button, not just an icon. I didn't like assuming the icon didn't have a specific line height. I also wasn't a huge fan of using `button` selector instead of `.btn`, so that other button types can work here, too.

Feel free to argue my changes, @zarahzachz.