### PR TITLE
DE3280 - Header Profile Picture

### DIFF
--- a/assets/stylesheets/components/_images.scss
+++ b/assets/stylesheets/components/_images.scss
@@ -8,3 +8,12 @@
 svg use {
   fill: currentColor;
 }
+
+@for $i from 1 through 12 {
+  .img-size-#{$i} {
+    $dimensions: 16px;
+
+    height: $dimensions * $i;
+    width: $dimensions * $i;
+  }
+}

--- a/assets/stylesheets/layouts/_header.scss
+++ b/assets/stylesheets/layouts/_header.scss
@@ -19,7 +19,7 @@
     display: inline-block;
     margin-top: 1.125rem;
     svg {
-      color: $cr-black;
+      color: $cr-gray-light;
     }
     &:hover {
       cursor: pointer;

--- a/assets/stylesheets/layouts/_header.scss
+++ b/assets/stylesheets/layouts/_header.scss
@@ -124,16 +124,10 @@
     ul {
       padding: .3125rem 0;
     }
-    .nav-profile-image {
-      display: inline-block;
+    .img-size-2_25 {
       @include size(2.25rem, 2.25rem);
-      overflow: hidden;
       margin: .25rem;
-      background-color: #f5f5f5;
-      border: 2px solid $cr-gray-lighter;
-      img {
-        @include size(100%, 100%);
-      }
+      color: $cr-gray-lighter;
     }
   }
 
@@ -201,4 +195,31 @@
       }
     }
   }
+}
+
+.header .profile-picture {
+  position: relative;
+
+  .img-circle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    @include size(100%, 100%)
+    border-style: solid;
+    border-width: 2px;
+  }
+}
+
+.header .profile-picture-default {
+  background-image: url('//crossroads-media.imgix.net/images/avatar.svg');
+  background-position: center;
+  background-size: cover;
+}
+
+.header .profile-picture-overlay {
+  background-position: center;
+  background-size: cover;
+  position: absolute;
+  top: 0;
+  right: 0;
 }

--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -304,6 +304,9 @@ a[ng-click] {
 .push {
   margin: $line-height-computed;
 }
+.push-center {
+  margin: 0 auto;
+}
 .push-half {
   margin: $line-height-computed / 2;
 }


### PR DESCRIPTION
Signed in state of nav -- profile pic should be smaller & a circle (more on par with how it exists today)

I chose to nest these under `.header` to avoid conflict with connect for MVP launch, although I want to pull these out to be more generic after launch.

### Related PRs

- crdschurch/crds-shared-header#29