### PR TITLE
DE3299 - iOS input shadow

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -1,5 +1,6 @@
 .form-control {
   box-shadow: none;
+  -webkit-appearance: none;
 }
 
 // Text fields
@@ -69,6 +70,7 @@ textarea {
   .form-control {
     margin-top: 5px;
     margin-bottom: 5px;
+    -webkit-appearance: none;
   }
 
   .input-group-addon {


### PR DESCRIPTION
Add CSS rule to remove the subtle shadow on inputs in iOS Safari/mobile.

Corresponds with development branches on other repos.