### PR TITLE
US8179 - DDK dark theme

### DIFF
--- a/assets/stylesheets/layouts/_header.scss
+++ b/assets/stylesheets/layouts/_header.scss
@@ -53,6 +53,7 @@
 
       a:hover {
         background-color: lighten($cr-gray-lighter, 4);
+        color: $cr-gray-dark;
         text-decoration: none;
       }
     }
@@ -138,8 +139,8 @@
 }
 
 // Main nav menu
-.nav {
-  > li {
+.header {
+  li {
     position: static;
 
     > a {


### PR DESCRIPTION
(Cherry-picked from `US8179-dark-theme`)

Add a real fix to DDK header linting. It now follows our linting rules **AND** doesn't conflict with other headers.

Corresponds with crds-styleguide/development