### PR TITLE
DE3293 - Mobile Background Scroll

### DIFF
--- a/assets/stylesheets/base/_global.scss
+++ b/assets/stylesheets/base/_global.scss
@@ -17,8 +17,7 @@ body {
   font-weight: 300;
 }
 
-html.noscroll,
-body.noscroll {
+.noscroll {
   position: relative;
   height: 100%;
   overflow: hidden;

--- a/assets/stylesheets/base/_global.scss
+++ b/assets/stylesheets/base/_global.scss
@@ -17,6 +17,13 @@ body {
   font-weight: 300;
 }
 
+html.noscroll,
+body.noscroll {
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+}
+
 hr {
   margin-top: 1rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
Add support for a `.noscroll` class on `body`, `html`.

Corresponds with crdschurch/crds-shared-header#40.