### PR TITLE
DE3497 - Calendar text color update

### DIFF
--- a/assets/stylesheets/vendors/_datepicker.scss
+++ b/assets/stylesheets/vendors/_datepicker.scss
@@ -191,6 +191,7 @@ datepicker {
       }
     }
 
+    .text-info,
     .text-muted {
       color: $cr-gray-light;
     }


### PR DESCRIPTION
Fixed text color of current year/month/date.

Test by clicking the month and/or year, then selecting a non-current month/year. Click back into it. Text should be light-gray and not white.

Corresponds with crds-styleguide/development