### PR TITLE
US8372 - Inverted color class

### DIFF
--- a/assets/stylesheets/utilities/_colors.scss
+++ b/assets/stylesheets/utilities/_colors.scss
@@ -1,0 +1,5 @@
+/* Utility classes to change color of text */
+
+.text-white {
+  color: $cr-white;
+}

--- a/assets/stylesheets/utilities/_modules.scss
+++ b/assets/stylesheets/utilities/_modules.scss
@@ -1,2 +1,3 @@
 @import 'backgrounds';
+@import 'colors';
 @import 'utilities';

--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -79,10 +79,6 @@ a.underline,
   white-space: nowrap;
 }
 
-.white {
-  color: $cr-white;
-}
-
 @media only screen and (min-width: $screen-sm-min) {
   .sm-text-right {
     text-align: right;


### PR DESCRIPTION
Refactor white text utility class into its own partial and change naming convention to match Bootstrap's.
Corresponds with crdschurch/crds-styleguide#137

---
update DDK to include helper class that inverts font color to white for darker bkgs 