### PR TITLE
Defect/de3512 datepicker zoom

### DIFF
--- a/assets/stylesheets/vendors/_datepicker.scss
+++ b/assets/stylesheets/vendors/_datepicker.scss
@@ -8,15 +8,15 @@
 
 datepicker {
   $calendar-bg: $cr-white;
-  $calendar-text: $cr-gray-darker;
-  $calendar-border: $cr-gray-light;
+  $calendar-text: $cr-gray;
+  $calendar-border: $cr-gray-lighter;
   $calendar-active-bg: $cr-teal;
   $calendar-active-text: $cr-white;
   $calendar-active-border: $cr-teal;
   $calendar-disabled-bg: transparent;
   $calendar-disabled-text: lighten($cr-gray-light, 20);
   $calendar-hover-bg: $cr-gray-lighter;
-  $calendar-hover-text: $cr-gray-darker;
+  $calendar-hover-text: $cr-gray;
   $calendar-hover-border: $cr-gray;
 
   display: none;
@@ -135,16 +135,38 @@ datepicker {
           .text-muted {
             color: $calendar-active-text;
           }
+
+          .text-info {
+            &, &.text-muted {
+              color: $calendar-active-text;
+              font-weight: inherit;
+            }
+          }
         }
 
         &:hover {
           background: $calendar-hover-bg;
           border-color: $calendar-hover-border;
           color: $calendar-hover-text;
+
+          .text-muted {
+            color: $calendar-hover-text;
+          }
         }
 
         .text-muted {
-          color: $cr-gray-light;
+          color: darken($cr-gray-lighter, 10);
+
+          &:hover {
+            color: $calendar-hover-text;
+          }
+        }
+
+        .text-info {
+          &, &.text-muted {
+            color: $cr-black;
+            font-weight: 400;
+          }
         }
       }
     }
@@ -185,11 +207,6 @@ datepicker {
         color: $calendar-active-text;
       }
     }
-
-    .text-info,
-    .text-muted {
-      color: $cr-gray-light;
-    }
   }
 
   .dark-theme & {
@@ -201,7 +218,7 @@ datepicker {
     $calendar-active-border: $cr-teal;
     $calendar-disabled-text: $cr-gray-dark;
     $calendar-hover-bg: $calendar-bg;
-    $calendar-hover-text: $calendar-text;
+    $calendar-hover-text: $cr-gray-dark;
     $calendar-hover-border: $calendar-border;
 
     thead {
@@ -278,6 +295,13 @@ datepicker {
 
           .text-muted {
             color: darken($cr-gray, 5);
+          }
+
+          .text-info {
+            &, &.text-muted {
+              color: $calendar-active-text;
+              font-weight: inherit;
+            }
           }
         }
       }

--- a/assets/stylesheets/vendors/_datepicker.scss
+++ b/assets/stylesheets/vendors/_datepicker.scss
@@ -78,17 +78,12 @@ datepicker {
   }
 
   .glyphicon {
-    @extend .icon;
-    @extend .icon-1;
-
-    &.glyphicon-chevron-left {
-      @extend .chevron-left;
+    &.glyphicon-chevron-left:before {
+      content: url('http://crossroads-media.s3.amazonaws.com/images/chevron-left-black.png');
     }
-    &.glyphicon-chevron-right {
-      @extend .chevron-right;
+    &.glyphicon-chevron-right:before {
+      content: url('http://crossroads-media.s3.amazonaws.com/images/chevron-right-black.png');
     }
-
-    background-size: cover;
   }
 
   tbody {
@@ -319,6 +314,17 @@ datepicker {
         span {
           color: $calendar-active-text;
         }
+      }
+    }
+
+    .glyphicon {
+      &.glyphicon-chevron-left:before {
+        content: url('http://crossroads-media.s3.amazonaws.com/images/chevron-left-white.png');
+        opacity: .25;
+      }
+      &.glyphicon-chevron-right:before {
+        content: url('http://crossroads-media.s3.amazonaws.com/images/chevron-right-white.png');
+        opacity: .25;
       }
     }
   }


### PR DESCRIPTION
Update the colors used on datepicker. Increase contrast/obviousness of current day/month/year. 
Fix the stretchiness of the datepicker by removing the SVG icon solution.
Corresponds with crds-embed/development & crds-styleguide/development

---
On Chrome, go to https://design-int.crossroads.net/ui/forms/datepicker and increase or decrease the zoom level, now try to go back to previous zoom level you see something like this:


Similar behavior is on embed - https://embedint.crossroads.net/?type=donation

Also current month should be more visible it's now kind of greyed out ...

