### PR TITLE
Feature/us6288 add cards to ddk

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -1,22 +1,99 @@
 .card {
-  margin-right: 1rem;
-  min-width: 200px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .card-block {
-  padding: 1rem;
+  padding: 0 2rem 2rem;
 }
 
 .card-title {
+  color: $cr-gray-dark;
+  line-height: 1;
+}
+
+.card-title--overlap {
+  background-color: $cr-white;
   font-family: $condensed-extra-font-face;
   font-size: 2.125rem;
-  font-weight: 600;
-  margin-top: 0;
-  margin-bottom: 0;
-  line-height: 1.5;
+  font-weight: 500;
+
+  display: inline-block;
+  margin: -1.5rem -.75rem;
+  padding: .25rem .75rem;
+}
+
+.card-text:before {
+  color: $cr-gray-light;
+  content: '\2014';
+  display: block;
+  font-weight: 100;
+  padding-bottom: .25rem;
 }
 
 .card-deck {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  overflow-x: scroll;
+  overflow-x: auto;
+
+  @media (min-width: $screen-sm) {
+    -webkit-flex-flow: row wrap;
+    -ms-flex-flow: row wrap;
+    flex-flow: row wrap;
+    overflow-y: visible;
+  }
+
+  .card {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-flex: 1;
+    -webkit-flex: 0 0 270px;
+    -ms-flex: 0 0 270px;
+    flex: 0 0 270px;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    margin-bottom: 1rem;
+    margin-right: 1rem;
+
+    @media (min-width: $screen-sm) {
+      flex-grow: 0;
+      flex-shrink: 0;
+      flex-basis: calc(25% - .75rem);
+
+      &:nth-of-type(4n) {
+        margin-right: 0;
+      }
+    }
+
+  }
+}
+
+.card-deck--carousel {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+
+  .card {
+    -webkit-flex: 0 0 270px;
+    -ms-flex: 0 0 270px;
+    flex: 0 0 270px;
+  }
+
+  .card:nth-of-type(4n) {
+    margin-right: 1rem;
+  }
 }

--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -1,5 +1,6 @@
 .card {
-  border: 1px solid red;
+  margin-right: 1rem;
+  min-width: 200px;
 }
 
 .card-block {
@@ -10,9 +11,12 @@
   font-family: $condensed-extra-font-face;
   font-size: 2.125rem;
   font-weight: 600;
+  margin-top: 0;
+  margin-bottom: 0;
+  line-height: 1.5;
 }
 
 .card-deck {
   display: flex;
-
+  overflow-x: scroll;
 }

--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -1,5 +1,5 @@
 .card-block {
-  padding: 1rem 2rem;
+  padding: 1rem;
 }
 
 .card-title {
@@ -14,8 +14,8 @@
   font-weight: 500;
 
   display: inline-block;
-  margin: -2rem -.75rem;
-  padding: .25rem .75rem;
+  margin: -2rem -.5rem;
+  padding: .25rem .5rem;
 }
 
 .card-title--overlap:after {
@@ -73,6 +73,16 @@
 
     @media (min-width: $screen-sm) {
       max-width: 25%;
+    }
+  }
+
+  .card-text {
+    font-size: $font-size-small;
+
+    address {
+      font-size: $font-size-small;
+      background: transparent;
+      padding: 0;
     }
   }
 }

--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -1,0 +1,18 @@
+.card {
+  border: 1px solid red;
+}
+
+.card-block {
+  padding: 1rem;
+}
+
+.card-title {
+  font-family: $condensed-extra-font-face;
+  font-size: 2.125rem;
+  font-weight: 600;
+}
+
+.card-deck {
+  display: flex;
+
+}

--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -1,16 +1,3 @@
-.card {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
 .card-block {
   padding: 1rem 2rem;
 }
@@ -82,6 +69,7 @@
     flex-direction: column;
     margin-bottom: 1rem;
     padding: 0 .5rem;
+    position: relative;
 
     @media (min-width: $screen-sm) {
       max-width: 25%;

--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -12,7 +12,7 @@
 }
 
 .card-block {
-  padding: 0 2rem 2rem;
+  padding: 1rem 2rem;
 }
 
 .card-title {
@@ -27,16 +27,29 @@
   font-weight: 500;
 
   display: inline-block;
-  margin: -1.5rem -.75rem;
+  margin: -2rem -.75rem;
   padding: .25rem .75rem;
 }
 
-.card-text:before {
+.card-title--overlap:after {
   color: $cr-gray-light;
   content: '\2014';
   display: block;
+  font-family: $base-font-face;
+  font-size: 1.25rem;
   font-weight: 100;
+  line-height: 1.5;
   padding-bottom: .25rem;
+}
+
+.card-link:not(:last-of-type) {
+  margin-right: .5rem;
+}
+
+.card-subtitle {
+  font-size: $font-size-smaller;
+  font-weight: 600;
+  text-transform: uppercase;
 }
 
 .card-deck {
@@ -59,27 +72,20 @@
     display: -ms-flexbox;
     display: flex;
     -webkit-box-flex: 1;
-    -webkit-flex: 0 0 270px;
-    -ms-flex: 0 0 270px;
-    flex: 0 0 270px;
+    -webkit-flex: 1 0 270px;;
+    -ms-flex: 1 0 270px;;
+    flex: 1 0 270px;;
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
     margin-bottom: 1rem;
-    margin-right: 1rem;
+    padding: 0 .5rem;
 
     @media (min-width: $screen-sm) {
-      flex-grow: 0;
-      flex-shrink: 0;
-      flex-basis: calc(25% - .75rem);
-
-      &:nth-of-type(4n) {
-        margin-right: 0;
-      }
+      max-width: 25%;
     }
-
   }
 }
 
@@ -91,9 +97,5 @@
     -webkit-flex: 0 0 270px;
     -ms-flex: 0 0 270px;
     flex: 0 0 270px;
-  }
-
-  .card:nth-of-type(4n) {
-    margin-right: 1rem;
   }
 }

--- a/assets/stylesheets/components/_modules.scss
+++ b/assets/stylesheets/components/_modules.scss
@@ -12,3 +12,4 @@
 @import 'labels';
 @import 'media-objects';
 @import 'maps';
+@import 'cards';


### PR DESCRIPTION
Implement card styles from /live to DDK.
+ Include basic card component (consists of an image, header and text).
+ In a group of cards, every card should be the same height (dependent on the longest length of content in a card).

Corresponds with crdschurch/crds-styleguide#145