### PR TITLE
US8560 - Homepage Anywhere

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -305,6 +305,14 @@ a {
   }
 }
 
+// Buttons
+.btn-block-mobile {
+  @media only screen and (max-width: $screen-sm-max) {
+    display: block;
+    width: 100%;
+  }
+}
+
 // Flexbox button groups - Horizontal layout
 .btn-group-row {
   display: flex;

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -305,9 +305,9 @@ a {
   }
 }
 
-// Buttons
+// Block-level buttons on mobile screens
 .btn-block-mobile {
-  @media only screen and (max-width: $screen-sm-max) {
+  @media only screen and (max-width: $screen-xs-max) {
     display: block;
     width: 100%;
   }

--- a/assets/stylesheets/utilities/_backgrounds.scss
+++ b/assets/stylesheets/utilities/_backgrounds.scss
@@ -29,3 +29,9 @@
 .bg-charcoal {
   @include crds-bg-variant(lighten($cr-gray-darker, .75), $cr-gray);
 }
+
+.bg-cover-image {
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
+}

--- a/assets/stylesheets/utilities/_colors.scss
+++ b/assets/stylesheets/utilities/_colors.scss
@@ -7,3 +7,7 @@
 .text-black {
   color: $cr-black;
 }
+
+.text-gray-dark {
+  color: $cr-gray-dark;
+}

--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -689,6 +689,7 @@ a.underline,
 
 
 
+
 /* 12. Misc. */
 
 .pointer {
@@ -707,6 +708,14 @@ a.underline,
 
 .full-width {
   width: 100%;
+}
+
+.full-height {
+  height: 100%;
+}
+
+.flex {
+  display: flex;
 }
 
 // Empty href attributes for UI Bootstrap

--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -706,6 +706,14 @@ a.underline,
   }
 }
 
+.position-relative {
+  position: relative;
+}
+
+.position-absolute {
+  position: absolute;
+}
+
 .full-width {
   width: 100%;
 }
@@ -714,8 +722,61 @@ a.underline,
   height: 100%;
 }
 
-.flex {
-  display: flex;
+.half-width {
+  width: 50%;
+}
+
+.half-height {
+  height: 50%;
+}
+
+.display-table {
+  display: table;
+}
+
+.display-table-cell {
+  display: table-cell;
+}
+
+@each $label, $size in (
+  xs: $screen-xs-min,
+  sm: $screen-sm-min,
+  md: $screen-md-min,
+  lg: $screen-lg-min
+) {
+  @media only screen and (min-width: $size) {
+    .full-width-#{$label} {
+      width: 100%;
+    }
+
+    .full-height-#{$label} {
+      height: 100%;
+    }
+
+    .half-width-#{$label} {
+      width: 50%;
+    }
+
+    .half-height-#{$label} {
+      height: 50%;
+    }
+
+    .display-table-#{$label} {
+      display: table;
+    }
+
+    .display-table-cell-#{$label} {
+      display: table-cell;
+    }
+
+    .position-relative-#{$label} {
+      position: relative;
+    }
+
+    .position-absolute-#{$label} {
+      position: absolute;
+    }
+  }
 }
 
 // Empty href attributes for UI Bootstrap


### PR DESCRIPTION
I added a couple utility classes to help make this section look right.

This should be previewed through Maestro locally, using this branch of crds-styles, linked appropriately within Maestro.

The markup can be found in the `HomepageAnywhere` content block in contentint. The image may not be right, but I'm more worried about the styles than the actual content. 

I will create content blocks for demo and prod manually after we are happy with this.

I'm also not sure if it necessary to write copy for the DDK for the added utility classes. Thoughts?

---

Acceptance Criteria:

> Given a crds.net user
> When I view the homepage
> Then I should see a promo block that provides information about Crossroads Anywhere that matches the approved design.