### PR TITLE
US8773 - Card style tweaks

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -1,4 +1,9 @@
+.card {
+  margin-bottom: 1rem;
+}
+
 .card-block {
+  font-size: .875rem;
   padding: 1rem;
 }
 
@@ -12,7 +17,6 @@
   font-family: $condensed-extra-font-face;
   font-size: 2.125rem;
   font-weight: 500;
-
   display: inline-block;
   margin: -2rem -.5rem;
   padding: .25rem .5rem;
@@ -38,14 +42,15 @@
   color: $cr-gray-dark;
   content: 'Current Series';
   font-family: $accent-font-face;
-  font-size: $font-size-small;
+  font-size: .8125rem;
   font-style: italic;
   padding: .5rem .75rem;
   position: relative;
-  top: -25px;
+  top: -30px;
 }
 
 .card-subtitle {
+  color: $cr-gray-light;
   font-size: $font-size-smaller;
   font-weight: 600;
   text-transform: uppercase;


### PR DESCRIPTION
Update styles on individual card components.

Corresponds with crdschurch/crds-styleguide#160

---
Feedback from Rob: 

*Cards*
- All `.card { margin-bottom: 1rem; }` `.card-block { font-size: 14px;` }
- Default, h5 `color: $cr-gray-light`
- Card w/ Caption label  `.card-caption:before { top: -30px; font-size: 13px;}`