### PR TITLE
US8725 - Jumbotron Revisions

### DIFF
--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -1,5 +1,7 @@
 .jumbotron {
   text-align: center;
+  padding-top: 48px;
+  padding-bottom: 48px;
 
   &[style*='background-image'],
   &.bg-video {
@@ -22,6 +24,26 @@
     position: relative;
     background-color: transparent;
     overflow: hidden;
+  }
+
+  &.jumbotron-sm {
+    padding-top: 32px;
+    padding-bottom: 32px;
+  }
+
+  &.jumbotron-md {
+    padding-top: 48px;
+    padding-bottom: 48px;
+  }
+
+  &.jumbotron-lg {
+    padding-top: 80px;
+    padding-bottom: 80px;
+  }
+
+  &.jumbotron-xl {
+    padding-top: 112px;
+    padding-bottom: 112px;
   }
 
   .container &,

--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -24,6 +24,11 @@
     overflow: hidden;
   }
 
+  .container &,
+  .container-fluid & {
+    border-radius: 0;
+  }
+
   .bg-video-player {
     position: absolute;
     top: 0;
@@ -43,13 +48,32 @@
     }
   }
 
-  .video-full-size {
+  .inline-video-player {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 1;
+    opacity: 0;
+    z-index: -4;
+
+    &.active {
+      opacity: 1;
+      z-index: 1;
+    }
+
+    iframe {
+      min-width: 100%;
+      min-height: 100%;
+    }
+
+    .close-video {
+      color: $cr-white;
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      z-index: 2;
+    }
   }
 
   .preloader-wrapper {
@@ -68,7 +92,7 @@
   }
 
   .title {
-    margin: 1.75rem;
+    margin: 1rem 0;
     font-family: $base-font-face;
     font-weight: 100;
     font-size: 4.25rem;
@@ -83,11 +107,13 @@
   .small-heading {
     font-weight: 400;
     letter-spacing: 1px;
-    font-size: 1rem;
+    font-size: .85rem;
+    line-height: 1;
+    opacity: .8;
   }
 
   a.btn {
-    margin: 1rem;
+    margin: 1rem .25rem 0;
   }
 
   a.btn-large {

--- a/assets/stylesheets/components/_preloader.scss
+++ b/assets/stylesheets/components/_preloader.scss
@@ -5,19 +5,34 @@
 }
 
 .preloader {
-  position: fixed;
+  position: absolute;
   display: block;
-  top: calc(20% - 37.5px);
+  top: calc(50% - 37.5px);
   left: calc(50% - 37.5px);
   width: 75px;
   height: 75px;
   margin: 0 auto;
   background: transparent;
   animation: rotateInitLoadingSpinner 700ms linear infinite;
+
+  &.preloader--top-right {
+    top: 37.5px;
+    right: 37.5px;
+    left: auto;
+  }
+
+  &.preloader--small {
+    width: 32px;
+    height: 32px;
+    &.preloader--top-right {
+      top: 16px;
+      right: 16px;
+    }
+  }
 }
 
 .preloader-wrapper {
-  position: fixed;
+  position: absolute;
   top: 0;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
- `.container .jumbotron, .container-fluid .jumbotron { border-radius: 0; }`
- `.jumbotron { padding-top: 150px; padding-bottom: 150px; }` <-- (100px @ mobile) 
- `.jumbotron .small-heading { font-size: .85rem; line-height: 1; opacity: .8;}`
- `.jumbotron .title { margin: 1rem 0; }`
- `.jumbotron a.btn { margin: 1rem .25rem 0; }`
- Padding helper: Default to 48px. Then small (32px), large (80px), xlarge (112px). 
- Move loading spinner to top right corner of container; make smaller
- support different video for bkg & button
- both video links should be editable via CMS
- add close btn while video is playing 
- automatically go back to jumbotron once video ends

---

Corresponds with crdschurch/crds-styleguide#163 and crdschurch/crds-maestro#150.
