### PR TITLE
US8429 - Block Level Buttons

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -305,6 +305,14 @@ a {
   }
 }
 
+// Block-level buttons on mobile screens
+.btn-block-mobile {
+  @media only screen and (max-width: $screen-xs-max) {
+    display: block;
+    width: 100%;
+  }
+}
+
 // Flexbox button groups - Horizontal layout
 .btn-group-row {
   display: flex;

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -223,6 +223,13 @@
   > .btn {
     width: auto;
   }
+
+  >.btn-block-mobile {
+    @media only screen and (max-width: $screen-xs-max) {
+      display: block;
+      width: 100%;
+    }
+  }
 }
 
 // Toggle button group

--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -98,7 +98,7 @@
     }
   }
 
-  .preloader-wrapper {
+  .inline-preloader-wrapper {
     position: absolute;
     top: 0;
     left: 0;

--- a/assets/stylesheets/components/_preloader.scss
+++ b/assets/stylesheets/components/_preloader.scss
@@ -1,10 +1,10 @@
-@keyframes rotateInitLoadingSpinner {
+@keyframes rotateInlinePreloader {
   100% {
     transform:rotate(360deg);
   }
 }
 
-.preloader {
+.inline-preloader {
   position: absolute;
   display: block;
   top: calc(50% - 37.5px);
@@ -13,25 +13,25 @@
   height: 75px;
   margin: 0 auto;
   background: transparent;
-  animation: rotateInitLoadingSpinner 700ms linear infinite;
+  animation: rotateInlinePreloader 700ms linear infinite;
 
-  &.preloader--top-right {
+  &.inline-preloader--top-right {
     top: 37.5px;
     right: 37.5px;
     left: auto;
   }
 
-  &.preloader--small {
+  &.inline-preloader--small {
     width: 32px;
     height: 32px;
-    &.preloader--top-right {
+    &.inline-preloader--top-right {
       top: 16px;
       right: 16px;
     }
   }
 }
 
-.preloader-wrapper {
+.inline-preloader-wrapper {
   position: absolute;
   top: 0;
   bottom: 0;


### PR DESCRIPTION
Given a developer viewing the DDK
When I view utility classes
Then i should see the .btn-block-mobile selector with a description of what it will do to help me make awesome buttons. 

Given a user viewing /connect
When I view a CTA throughout the application on mobile
Then it should be displayed 100% wide, block-level on my tiny screen

Given a user viewing /connect
When I view a CTA throughout the application on desktop
Then I should see inline-block elements that do not fill up 100% of my screen width. 

---

Corresponds with:

- crdschurch/crds-styleguide#166
- crdschurch/crds-maestro#151
- crdschurch/crds-connect#411