### PR TITLE
DE3747 - Getting Started Buttons

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -226,7 +226,6 @@
 
   >.btn-block-mobile {
     @media only screen and (max-width: $screen-xs-max) {
-      display: block;
       width: 100%;
     }
   }
@@ -315,7 +314,6 @@ a {
 // Block-level buttons on mobile screens
 .btn-block-mobile {
   @media only screen and (max-width: $screen-xs-max) {
-    display: block;
     width: 100%;
   }
 }


### PR DESCRIPTION
Fix button block mobile -- they don't need to display as block. In response to:

> on the getting started page on iOS, the Host buttons bleeds into the footer