### PR TITLE
DE3762 - Collection header font

### DIFF
--- a/assets/stylesheets/components/_typography.scss
+++ b/assets/stylesheets/components/_typography.scss
@@ -183,7 +183,7 @@
   color: $cr-gray;
   font-family: $base-font-face;
   font-size: 1.3125rem; // 21px
-  font-weight: 100;
+  font-weight: 300;
   padding-top: .65em;
 
   .dark-theme & {


### PR DESCRIPTION
Update font weight of the collection header font.

No corresponding PRs.

---
collection-header should have `font-weight: 300`