### PR TITLE
DE3753 - X Button Edge

### DIFF
--- a/assets/stylesheets/components/_images.scss
+++ b/assets/stylesheets/components/_images.scss
@@ -5,7 +5,8 @@
   }
 }
 
-a > svg {
+a > svg,
+span > svg {
   pointer-events: none;
 }
 


### PR DESCRIPTION
The X is not clickable in the edge browser

Note: this is related to the Finder, on the search bar we added a clear icon.

---

This requires the resolution DE3754 in order to work properly.