### PR TITLE
US8888 - Jumbotron BG Image and Inline Video

### DIFF
--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -1,4 +1,5 @@
 .jumbotron {
+  position: relative;
   text-align: center;
   padding-top: 48px;
   padding-bottom: 48px;


### PR DESCRIPTION
Given a user adding a jumbotron element to a page in the CMS
When the jumbotron contains a still background image
Then I should be able to invoke an inline video element from a CTA that replaces that jumbotron. 

Given a user viewing the jumbotron elements in the DDK
When reviewing the implementation details
Then I should see an example that plays an inline video on top of a still image.

---

Corresponds with crdschurch/crds-maestro#172 and crdschurch/crds-styleguide#176.