### PR TITLE
DE3843 - Searchbar hotspot

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -285,6 +285,16 @@ textarea {
     .addon-btn {
       background: transparent;
       border: 0;
+      position: relative;
+
+      &:after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
 
       .icon {
         vertical-align: middle;

--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -285,17 +285,7 @@ textarea {
     .addon-btn {
       background: transparent;
       border: 0;
-      position: relative;
       padding: 4px 6px;
-
-      &:after {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-      }
 
       .icon {
         vertical-align: middle;

--- a/assets/stylesheets/components/_images.scss
+++ b/assets/stylesheets/components/_images.scss
@@ -5,8 +5,7 @@
   }
 }
 
-a > svg,
-span > svg {
+* > svg {
   pointer-events: none;
 }
 


### PR DESCRIPTION
Test 'X' in searchbar on Edge 15. Problem was the `svg` nested within a `button` doesn't work - so click the 'X' part (pixels).

Corresponds with crdschurch/crds-maestro#178

---

In the Edge Browser, when I try to click the "X", it does not work all of the time. It seems like the Hot Spot is not quite in the right place as the "X" image