### PR TITLE
DE3842 - iPhone7 searchbar

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -285,6 +285,7 @@ textarea {
     .addon-btn {
       background: transparent;
       border: 0;
+      padding: 4px 6px; 
 
       .icon {
         vertical-align: middle;


### PR DESCRIPTION
Explicitly set padding on icon buttons. Safari/ios was inheriting extra-wide padding for some reason.

Bug is not visible on Chrome's devtools - test using the simulator.
No corresponding PRs