### PR TITLE
US9159 - Btn Indent Style

### DIFF
--- a/assets/stylesheets/components/_button-form-group.scss
+++ b/assets/stylesheets/components/_button-form-group.scss
@@ -25,7 +25,6 @@
 
   .custom-input {
     position: relative;
-    justify-content: flex-end;
     min-height: 2.75rem;
     overflow: hidden;
 

--- a/assets/stylesheets/components/_button-form-group.scss
+++ b/assets/stylesheets/components/_button-form-group.scss
@@ -24,18 +24,25 @@
   }
 
   .custom-input {
-    display: flex;
+    position: relative;
     justify-content: flex-end;
     min-height: 2.75rem;
     overflow: hidden;
 
-    .custom-input-icon {
-      padding: 15px 10px;
-      color: $cr-gray-light;
+    &:before {
+      position: absolute;
+      display: block;
+      left: 14px;
+      top: 0;
+      height: 100%;
+      width: 2px;
+      content: ' ';
+      background: $cr-gray-lighter;
     }
 
-    .custom-input-field {
-      flex-basis: calc(100% - 30px);
+    > * {
+      width: calc(100% - 32px);
+      margin-left: 32px;
     }
   }
 }

--- a/assets/stylesheets/components/_button-form-group.scss
+++ b/assets/stylesheets/components/_button-form-group.scss
@@ -32,17 +32,17 @@
     &:before {
       position: absolute;
       display: block;
-      left: 14px;
+      left: 0;
       top: 0;
       height: 100%;
-      width: 2px;
+      width: 3px;
       content: ' ';
       background: $cr-gray-lighter;
     }
 
     > * {
-      width: calc(100% - 32px);
-      margin-left: 32px;
+      width: calc(100% - 19px);
+      margin-left: 19px;
     }
   }
 }


### PR DESCRIPTION
Given a designer/developer 
When implementing a btn form group on a Crds application
Then I should find implementation details for the updated btn group in the DDK with the vertical rule for indented/child options rather than the caret

Given a crds.net/groups user
When starting a group
Then I should see the updated btn form group implemented within any selections that have nested child options 

---

Corresponds to crdschurch/crds-styleguide#189 and crdschurch/crds-connect#508.