### PR TITLE
DE3971 Validation Styles

### DIFF
--- a/assets/stylesheets/components/_form-states.scss
+++ b/assets/stylesheets/components/_form-states.scss
@@ -93,6 +93,7 @@ select {
 .error {
   &.help-block {
     color: $alert-danger;
+    text-align: left;
 
     > p:last-child {
       margin-bottom: 0;


### PR DESCRIPTION
Force all input help-blocks to be left-aligned.

See also crdschurch/crds-connect#520