### PR TITLE
US9172 - Single Btn Dropdown

### DIFF
--- a/assets/stylesheets/components/_button-dropdowns.scss
+++ b/assets/stylesheets/components/_button-dropdowns.scss
@@ -12,7 +12,7 @@
     }
 
     .icon {
-      margin-top: 2px;
+      margin: 2px 0 0 4px;
       height: 14px;
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "crds-styles",
-  "version": "0.10.0",
+  "version": "0.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes the _pinking_ by making the spacing between arrow and text smaller and more consistent with Bootstrap.