### PR TITLE
DE4077 - Active Filter Button

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -281,7 +281,7 @@ textarea {
     position: absolute;
     top: 0;
     left: 0;
-    width: calc(100% - 58px);
+    width: calc(100% - 68px);
     height: 42px;
     z-index: 0;
     background: lighten(rgba(231,231,231,1), 5);


### PR DESCRIPTION
Current behavior:
When filters are applied, equalizer icon does not change color to reflect the enabled state.


Expected behavior:
When returned to map/list page, the equalizer icon in the search bar should display an enabled state. Use $cr-teal for this. 

---

crdschurch/crds-connect#605
