### PR TITLE
DE4170 - Multiselect btns active state

### DIFF
--- a/assets/stylesheets/components/_button-form-group.scss
+++ b/assets/stylesheets/components/_button-form-group.scss
@@ -14,8 +14,14 @@
       }
     }
 
-    &.btn-outline {
+    &.btn-outline:hover {
       &:hover {
+        background: transparent;
+        border-color: rgba($cr-gray-light, .75);
+        color: $cr-gray-light;
+      }
+
+      &.active:hover {
         background: $cr-teal;
         border-color: $cr-teal;
         color: $cr-white;

--- a/assets/stylesheets/components/_button-form-group.scss
+++ b/assets/stylesheets/components/_button-form-group.scss
@@ -14,7 +14,7 @@
       }
     }
 
-    &.btn-outline:hover {
+    &.btn-outline {
       &:hover {
         background: transparent;
         border-color: rgba($cr-gray-light, .75);


### PR DESCRIPTION
Add styles for the hover state of form btn select groups.

These styles effect the hover state of this UI component. If active, the button should retain its teal look. If inactive and hovered over, it should be white/non-styled.

No corresponding stuff.