### PR TITLE
IE 11 Dropdown button styling fix

### DIFF
--- a/assets/stylesheets/components/_button-dropdowns.scss
+++ b/assets/stylesheets/components/_button-dropdowns.scss
@@ -14,6 +14,8 @@
     .icon {
       margin: 2px 0 0 4px;
       height: 14px;
+      // specified width to prevent IE 11 width:auto issue
+      width: 12px;
     }
   }
 


### PR DESCRIPTION
Without a specified width, IE has trouble scaling SVGs. In the case of our dropdown button, IE 11 thinks that the SVG (chevron) should be 100% width.