### PR TITLE
US9932 Add style for cell-vertical-bottom

### DIFF
--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -202,7 +202,7 @@ a.underline,
   width: 100%;
 }
 
-.cell-vertical-bottom {
+.vertical-align-bottom {
   vertical-align: bottom;
 }
 

--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -202,7 +202,9 @@ a.underline,
   width: 100%;
 }
 
-
+.cell-vertical-bottom {
+  vertical-align: bottom;
+}
 
 
 /* 5. Border stuff */


### PR DESCRIPTION
DE4293 worked to get the Homepage Anywhere section of the Homepage to
display the associated image correctly. In that solution, an inline
styling was applied in the CMS. This body of work extracts that inline
styling and creats a new class in crds-styles to be applied to the cell
that contains that image. The inline styling in the CMS will be removed
and the new style will be applied to that element after this pull
request gets merged.