### PR TITLE
US9480 - Input Addon Focus

### DIFF
--- a/assets/stylesheets/components/_forms.scss
+++ b/assets/stylesheets/components/_forms.scss
@@ -119,7 +119,7 @@ textarea {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    z-index: 3;
+    z-index: 4;
 
     i, .icon {
       background-size: 16px;


### PR DESCRIPTION
The input addon (https://design.crossroads.net/ui-components/atoms/forms/groups) should persist the icon when the field is focused.