### PR TITLE
DE4353 - Dropdown btn

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -2,6 +2,7 @@
   border-radius: $border-radius-base;
   margin-top: 5px;
   margin-bottom: 5px;
+  white-space: normal;
 
   &.active,
   &:active,


### PR DESCRIPTION
Change white-space rule to default 'normal' value so it doesn't break line on dropdown button in FF.

No corresponding PRs.