### PR TITLE
Add .btn to target button elements

### DIFF
--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -151,11 +151,13 @@
     opacity: .8;
   }
 
-  a.btn {
+  a.btn,
+  .btn {
     margin: 1rem .25rem 0;
   }
 
-  a.btn-large {
+  a.btn-large,
+  .btn-large {
     padding-top: .75rem;
     padding-bottom: .75rem;
   }


### PR DESCRIPTION
Updated these selectors to look for any element with the class `.btn` per @zarahzachz. Leaving the old selectors just in case.