### PR TITLE
US10588 Add Disabled & Read Only Form Controls to DDK  …

### DIFF
--- a/assets/stylesheets/components/_form-states.scss
+++ b/assets/stylesheets/components/_form-states.scss
@@ -15,6 +15,24 @@
     border-color: $input-border-focus;
     box-shadow: inset 0 0 0 1px rgba($input-border-focus, .5);
   }
+  &[disabled] {
+    color: $cr-gray-light;
+    background-color: lighten($input-color-placeholder, 25);
+    border: solid 1px lighten($input-color-placeholder, 25);
+    .dark-theme & {
+      background-color: $cr-gray-dark;
+      border: solid 1px $cr-gray-dark;
+    }
+  }
+  &[readonly] {
+    color: $cr-gray-light;
+    background-color: $cr-white;
+    border: solid 1px $cr-gray-lighter;
+    .dark-theme & {
+      background-color: $cr-black;
+      border: solid 1px $cr-gray;
+    }
+  }
 }
 
 .checkbox {


### PR DESCRIPTION
Given a user
When viewing any form element marked as disabled or readonly
Then I should see a clear distinction from other active elements:

Disabled inputs prevent user interactions and appear lighter in color and add a not-allowed cursor.
Read-only inputs appear lighter, but keep the standard cursor

Given a user
When viewing the form states page in the DDK
Then I should see representations for input fields in disabled and read-only states.

Linked with crdschurch/crds-styleguide#255