### PR TITLE
Defect/de4875 ios btn hover state

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -179,10 +179,9 @@
     color: $btn-default-color;
 
     @media (pointer:coarse) {
-      // background-color: $btn-default-bg;
-      // border-color: $btn-default-border;
-      // color: $btn-default-color;
-      background: red;
+      background-color: $btn-default-bg;
+      border-color: $btn-default-border;
+      color: $btn-default-color;
     }
   }
 

--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -177,7 +177,15 @@
     background-color: darken($btn-default-bg, 10);
     border-color: darken($btn-default-border, 10);
     color: $btn-default-color;
+
+    @media (pointer:coarse) {
+      // background-color: $btn-default-bg;
+      // border-color: $btn-default-border;
+      // color: $btn-default-color;
+      background: red;
+    }
   }
+
 
   :focus {
     border-color: $input-border-focus;


### PR DESCRIPTION
Adding an [interaction media query](https://caniuse.com/#feat=css-media-interaction) to remove hover state styles from touch/XBox kinect devices. This feature shows as being supported in current versions of Chrome, Chrome for Android and iOS Safari, so I *think* this does the trick in targeting styles on touch devices. Would love feedback here.

I ran it locally through browser stack and it looks good.

No corresponding PRs.