### PR TITLE
DE4891 - iOS active buttons

### DIFF
--- a/assets/stylesheets/components/_buttons.scss
+++ b/assets/stylesheets/components/_buttons.scss
@@ -323,6 +323,8 @@
       }
 
       &.btn-default {
+        -webkit-tap-highlight-color: $cr-teal;
+
         &:focus {
           border: 1px solid $input-border-focus;
           box-shadow: 0 0 0 1px $input-border-focus inset;


### PR DESCRIPTION
Add CSS to allow touch/tapping interaction on buttons in Chrome and Safari. Note that this fix works on both mobile (tapping the screen) and desktop (tapping a trackpad) for these browsers.

No corresponding PRs.