### PR TITLE
US10242 - Schedule Content Block on Live

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -1,5 +1,6 @@
 .card {
   margin-bottom: 1rem;
+  // DEPRECATION NOTICE: .card-caption is now .card-img-caption and .img-caption
   &.current-series .card-caption {
     @media screen and (min-width: $screen-sm) {
       @include make-sm-column(8);
@@ -86,6 +87,7 @@
   margin-right: .5rem;
 }
 
+// DEPRECATION NOTICE: .card-caption is now .card-img-caption and .img-caption
 .card-caption:before {
   background-color: $cr-blue-lighter;
   color: $cr-gray-dark;
@@ -97,6 +99,35 @@
   position: relative;
   top: -30px;
 }
+
+.card-img-caption {
+  position: relative;
+
+  .img-caption {
+    background-color: $cr-blue-lighter;
+    bottom: -1rem;
+    color: $cr-gray-dark;
+    font-family: $accent-font-face;
+    font-size: .8125rem;
+    font-style: italic;
+    left: 50%;
+    padding: .5rem .75rem;
+    position: absolute;
+    transform: translate(-50%, 0);
+
+    &.img-caption--left {
+      left: 1rem;
+      transform: none;
+    }
+
+    &.img-caption--right {
+      left: auto;
+      right: 1rem;
+      transform: none;
+    }
+  }
+}
+
 
 .card-subtitle {
   color: $cr-gray-light;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "crds-styles",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Adjust card caption markup. Previously the "Current Series" label was built directly from the CMS. I kept that in place but left a deprecation note.

This adjustment is also reflected in the DDK's markup in crdschurch/crds-styleguide#292.

This is also part of a larger story which includes crdschurch/SS-CMS#491.