### PR TITLE
US12329 - Card Image Height

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -128,6 +128,12 @@
   }
 }
 
+.card img:not(.card-img-unrestrained) {
+  height: 200px;
+  object-fit: cover;
+  object-position: center;
+  width: 100%;
+}
 
 .card-subtitle {
   color: $cr-gray-light;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "crds-styles",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Normalize card image heights to 200px.

My approach here was to add the one height across the board with an option to disable it using a class. I thought that'd work better than pre-defining all the potential heights. Totally open to feedback.

Corresponds to crdschurch/crds-styleguide#315.