### PR TITLE
DE5385 - CONstraint

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -10,6 +10,14 @@
   > a {
     display: block;
   }
+
+  // Sets fixed height on images when applied
+  .card-img-constrained {
+    height: 200px;
+    object-fit: cover;
+    object-position: center;
+    width: 100%;
+  }
 }
 
 
@@ -126,13 +134,6 @@
       transform: none;
     }
   }
-}
-
-.card img:not(.card-img-unrestrained) {
-  height: 200px;
-  object-fit: cover;
-  object-position: center;
-  width: 100%;
 }
 
 .card-subtitle {


### PR DESCRIPTION
Refactor card height class. Now called "con"-strained and must be applied when you want an image to be a uniform height. Card images will not be 200px by default.

Corresponds with crdschurch/crds-styleguide#323 and crdschurch/SS-CMS#534