### PR TITLE
added subheading class handling

### DIFF
--- a/assets/stylesheets/components/_typography.scss
+++ b/assets/stylesheets/components/_typography.scss
@@ -195,7 +195,7 @@
   }
 }
 
-.component-header {
+.component-header, .subheading {
   font-family: $condensed-extra-font-face;
   font-size: $font-size-h3; // 32px
   font-weight: 500;


### PR DESCRIPTION
Add styles to global (crds-styles) to care for subheadings in migrated pages. In adding this class to global styles, we can prevent a significant amount of markdown refactoring.