### PR TITLE
US15517 - Media Label

### DIFF
--- a/assets/stylesheets/vendors/_modules.scss
+++ b/assets/stylesheets/vendors/_modules.scss
@@ -1,7 +1,7 @@
 // CSS linting will not run in this directory
 
-@import '~bootstrap-sass/assets/stylesheets/bootstrap';
-@import 'datepicker';
-@import 'timepicker';
-@import 'toast';
-@import 'wtf-forms';
+@import "~bootstrap-sass/assets/stylesheets/bootstrap.scss";
+@import "datepicker";
+@import "timepicker";
+@import "toast";
+@import "wtf-forms";

--- a/assets/stylesheets/vendors/_modules.scss
+++ b/assets/stylesheets/vendors/_modules.scss
@@ -1,7 +1,7 @@
 // CSS linting will not run in this directory
 
-@import "~bootstrap-sass/assets/stylesheets/bootstrap.scss";
-@import "datepicker";
-@import "timepicker";
-@import "toast";
-@import "wtf-forms";
+@import '~bootstrap-sass/assets/stylesheets/bootstrap.scss';
+@import 'datepicker';
+@import 'timepicker';
+@import 'toast';
+@import 'wtf-forms';


### PR DESCRIPTION
Use .scss extension for loading bootstrap so it doesn't look in
a subdirectory