### PR TITLE
DE6275 - CRDS Style Loader

### DIFF
--- a/assets/stylesheets/vendors/_modules.scss
+++ b/assets/stylesheets/vendors/_modules.scss
@@ -1,6 +1,6 @@
 // CSS linting will not run in this directory
 
-@import '~bootstrap-sass/assets/stylesheets/bootstrap.scss';
+@import '~bootstrap-sass/assets/stylesheets/_bootstrap.scss';
 @import 'datepicker';
 @import 'timepicker';
 @import 'toast';

--- a/package-lock.json
+++ b/package-lock.json
@@ -631,8 +631,7 @@
     "bootstrap-sass": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.0.tgz",
-      "integrity": "sha512-qdUyw4KmNNPSIdBadn+eyuuQFH0LsZlRCs6tor1zN8sQas7mnY5JNfemauraOdNPiFQd2gFeeo3gZjZZCuohZg==",
-      "dev": true
+      "integrity": "sha512-qdUyw4KmNNPSIdBadn+eyuuQFH0LsZlRCs6tor1zN8sQas7mnY5JNfemauraOdNPiFQd2gFeeo3gZjZZCuohZg=="
     },
     "boxen": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "aws-sdk": "^2.381.0",
+    "bootstrap-sass": "^3.4.0",
     "cheerio": "^1.0.0-rc.2",
     "commander": "^2.19.0",
     "lodash": "^4.17.11",
@@ -46,7 +47,6 @@
   },
   "devDependencies": {
     "autoprefixer": "^9.4.3",
-    "bootstrap-sass": "^3.4.0",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "postcss": "^7.0.7",


### PR DESCRIPTION
Always depend on bootstrap-sass package.

I tested this on crds-profile locally, and have informed the appropriate parties of the current workaround (to go back to 3.0.7) and next steps (move up to 3.1.1 after the next sprint).

And to ensure this will continue to work with Jekyll projects using the asset pipeline and submodule approach, I updated crds-media in crdschurch/crds-media#475.