### PR TITLE
US15898 Refactor Jumbotron Inline Video

### DIFF
--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable declaration-no-important */
+
 .jumbotron {
   position: relative;
   text-align: center;
@@ -143,7 +145,6 @@
     }
 
     svg {
-      opacity: 1;
       width: 24px;
       height: 24px;
     }
@@ -156,11 +157,18 @@
 
     .close-video {
       display: block;
+      opacity: 1;
     }
 
-    &:hover {
+    @media (min-width: $screen-sm) {
       .close-video {
-        opacity: 1;
+        opacity: 0;
+      }
+
+      &:hover {
+        .close-video {
+          opacity: 1;
+        }
       }
     }
   }

--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -1,5 +1,3 @@
-/* stylelint-disable declaration-no-important */
-
 .jumbotron {
   position: relative;
   text-align: center;
@@ -136,6 +134,7 @@
     padding-right: 10px;
     padding-bottom: 5px;
     opacity: 0;
+    cursor: pointer;
 
     @media (min-width: $screen-sm) {
       position: absolute;
@@ -150,10 +149,22 @@
     }
   }
 
+  .jumbotron-background-cover {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    background: $cr-black;
+    top: 0;
+    left: 0;
+    opacity: 0;
+  }
+
   &.inline-video.playing {
-    padding: 0 !important;
-    background-image: none!important;
-    background-color: black!important;
+    padding: 0;
+
+    .jumbotron-background-cover {
+      opacity: 1;
+    }
 
     .close-video {
       display: block;

--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -164,12 +164,10 @@
       .close-video {
         opacity: 0;
       }
+    }
 
-      &:hover {
-        .close-video {
-          opacity: 1;
-        }
-      }
+    &:hover .close-video {
+      opacity: 1;
     }
   }
 

--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -82,41 +82,57 @@
   }
 
   .inline-video-player {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    position: relative;
+    display: block;
+    background-color: $cr-black;
     opacity: 0;
     z-index: -4;
-    background-color: $cr-black;
-    @media screen and (max-width: $screen-sm) {
-      display: flex;
-      justify-content: center;
-      flex-direction: column;
-    }
+    height: 0;
+    padding: 0;
+    overflow: hidden;
 
     &.active {
       opacity: 1;
       z-index: 2;
+      padding-bottom: 56.25%;
     }
 
+
     iframe {
-      position: relative;
-      min-width: 100%;
-      min-height: 100%;
-      @media screen and (max-width: $screen-sm) {
-        width: 100%;
-        min-height: auto;
-      }
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      border: 0;
+      padding-top: 2rem;
     }
 
     .close-video {
       color: $cr-white;
+      background-color: $cr-black;
       position: absolute;
-      top: 1rem;
-      right: 1rem;
       z-index: 3;
+      opacity: 1;
+      height: 3rem;
+      width: 100%;
+      top: calc(-3rem - 15px);
+      right: 0;
+      text-align: right;
+      padding-top: 10px;
+      padding-right: 22px;
+      margin-top: 15px;
+
+      & > svg {
+        opacity: 0;
+      }
+    }
+
+    &.active:hover {
+      .close-video > svg {
+        opacity: 1;
+      }
     }
   }
 

--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -85,18 +85,31 @@
     position: relative;
     display: block;
     background-color: $cr-black;
+    height: 0;
+    width: 100%;
     opacity: 0;
     z-index: -4;
-    height: 0;
     padding: 0;
     overflow: hidden;
 
     &.active {
       opacity: 1;
       z-index: 2;
-      padding-bottom: 56.25%;
-    }
+      min-height: 360px;
+      padding-bottom: 0;
 
+      @media (min-width: $screen-sm) {
+        min-height: 0;
+        padding-bottom: 56.25%;
+        width: 90%;
+        margin-right: auto;
+        margin-left: auto;
+      }
+
+      @media (min-width: $screen-lg) {
+        width: 94%;
+      }
+    }
 
     iframe {
       position: absolute;
@@ -106,31 +119,47 @@
       height: 100%;
       width: 100%;
       border: 0;
-      padding-top: 2rem;
     }
+  }
+
+  .close-video {
+    color: $cr-white;
+    background-color: $cr-black;
+    position: relative;
+    display: none;
+    top: 0;
+    right: 0;
+    text-align: right;
+    padding-top: 10px;
+    padding-right: 10px;
+    padding-bottom: 5px;
+    opacity: 0;
+
+    @media (min-width: $screen-sm) {
+      position: absolute;
+      top: 1.5%;
+      right: 1%;
+      padding: 0;
+    }
+
+    svg {
+      opacity: 1;
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  &.inline-video.playing {
+    padding: 0 !important;
+    background-image: none!important;
+    background-color: black!important;
 
     .close-video {
-      color: $cr-white;
-      background-color: $cr-black;
-      position: absolute;
-      z-index: 3;
-      opacity: 1;
-      height: 3rem;
-      width: 100%;
-      top: calc(-3rem - 15px);
-      right: 0;
-      text-align: right;
-      padding-top: 10px;
-      padding-right: 22px;
-      margin-top: 15px;
-
-      & > svg {
-        opacity: 0;
-      }
+      display: block;
     }
 
-    &.active:hover {
-      .close-video > svg {
+    &:hover {
+      .close-video {
         opacity: 1;
       }
     }

--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -107,6 +107,7 @@
       }
 
       @media (min-width: $screen-lg) {
+        padding-bottom: 100vh;
         width: 94%;
       }
     }

--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -549,27 +549,27 @@ a.underline,
 
 /* 11. Padding rules */
 .hard {
-  padding: 0;
+  padding: 0 !important;
 }
 .hard-top {
-  padding-top: 0;
+  padding-top: 0 !important;
 }
 .hard-right {
-  padding-right: 0;
+  padding-right: 0 !important;
 }
 .hard-bottom {
-  padding-bottom: 0;
+  padding-bottom: 0 !important;
 }
 .hard-left {
-  padding-left: 0;
+  padding-left: 0 !important;
 }
 .hard-sides {
-  padding-right: 0;
-  padding-left: 0;
+  padding-right: 0 !important;
+  padding-left: 0 !important;
 }
 .hard-ends {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
 }
 .soft {
   padding: $line-height-computed;


### PR DESCRIPTION
## Problem
Jumbotron Inline Video has too much space above and below it on mobile and the white "x" covers the YouTube share button

## Solution
- Refactor Jumbotron to adjust which divs are `position: relative` and which are `position: absolute`
- Move the white "x" to the right of the video on desktop and hide it or move it below on mobile

### Corresponding Branch
This should be merged first: https://github.com/crdschurch/crds-jumbotron-video/pull/8
This is also part of the story and should be merged next: https://github.com/crdschurch/crds-styleguide/pull/395 

## Testing
You can test this [here](https://deploy-preview-395--crds-styleguide.netlify.com/ui-components/molecules/jumbotrons#inline-video) after the [crds-jumbotron-video](https://github.com/crdschurch/crds-jumbotron-video/pull/8) PR is merged and the JS updates in Cloudfront