### PR TITLE
DE6327 Card title overlap

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -101,7 +101,7 @@
   display: inline-block;
   font-family: $condensed-extra-font-face;
   font-size: 2.125rem;
-  margin: -2rem -0.5rem;
+  margin: -2rem -0.5rem 0;
   padding: 0.25rem 0.5rem;
   position: relative;
 
@@ -118,7 +118,6 @@
   font-size: 1.25rem;
   font-weight: 100;
   line-height: 1.5;
-  padding-bottom: 0.25rem;
 }
 
 .card-link:not(:last-of-type) {


### PR DESCRIPTION
adjust margin to see text below card title
adjust padding to even out the ::after element's spacing

Corresponding PR: https://github.com/crdschurch/crds-styleguide/pull/404