### PR TITLE
bring the whole video player z-index up

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -467,6 +467,6 @@
 }
 
 // fixes an issue where subtitles were under overlay
-.overlay-card .bmpui-ui-subtitle-overlay {
+.overlay-card .card-video-player {
   z-index: 1;
 }


### PR DESCRIPTION
@janssejl messed up that selector and didn't get the parent container. This will fix.