### PR TITLE
DE6903-sh-app-cta-bug

### DIFF
--- a/assets/stylesheets/components/_crds-components-skeleton-blocks.scss
+++ b/assets/stylesheets/components/_crds-components-skeleton-blocks.scss
@@ -2,7 +2,12 @@
 .shared-header-skeleton {
   min-height: 49px;
   position: relative;
-  z-index: 10;
+  z-index: 10; 
+
+  @supports(position: sticky){
+    position: sticky;
+    top: 0;
+  }
 }
 
 .shared-header {


### PR DESCRIPTION
Adds sticky position to header & skeleton for supported browsers

---

Note: This defect is only resolved if shared-header also has position sticky. A PR for this exists [here](https://github.com/crdschurch/crds-components/pull/59)

---

Corresponds to crdschurch/crds-net#967.