### PR TITLE
fix subtitles jumping on hover

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -465,3 +465,9 @@
 .card-video-player {
   transition: opacity 0.45s ease;
 }
+
+// prevent subtitles on autoplay cards from jumping
+.bmpui-ui-subtitle-overlay.bmpui-controlbar-visible {
+  bottom: 2em;
+  z-index: 1;
+}


### PR DESCRIPTION
Autoplaying cards with subtitles would jump when a user hovers over the card to reveal the controls UI which we've hidden. These two CSS properties, fix the subtitles to the bottom of the card while still allowing some hover animations (bg-shadow).