### PR TITLE
Adds crds-image skeleton

### DIFF
--- a/assets/stylesheets/components/_crds-components-skeleton-blocks.scss
+++ b/assets/stylesheets/components/_crds-components-skeleton-blocks.scss
@@ -31,7 +31,6 @@
     path {
       fill: $cr-white;
     }
-
   }
 }
 
@@ -48,4 +47,30 @@
 .shared-footer-skeleton {
   background-color: $cr-gray-lighter;
   min-height: 626px;
+}
+
+// --------------------------------------------------------
+
+.crds-image-skeleton {
+  animation: crdsImageSkeleton 2s infinite;
+  padding-bottom: 66.6666666667%;
+
+  &.loaded {
+    animation: none;
+    padding-bottom: 0;
+  }
+}
+
+@keyframes crdsImageSkeleton {
+  0% {
+    background: rgba($cr-gray-lighter, 0.75);
+  }
+
+  25% {
+    background: rgba($cr-gray-lighter, 0.5);
+  }
+
+  100% {
+    background: rgba($cr-gray-lighter, 0.75);
+  }
 }


### PR DESCRIPTION
Adds the required CSS for a loading skeleton for `<crds-image>` 

This goes with the Imgix resize work for the `<crds-image>` component in this [PR](https://github.com/crdschurch/crds-components/pull/265)