### PR TITLE
US19536 [Rebrand | Shared Header] Mega menu updates

### DIFF
--- a/assets/stylesheets/components/_crds-components-skeleton-blocks.scss
+++ b/assets/stylesheets/components/_crds-components-skeleton-blocks.scss
@@ -20,7 +20,7 @@
 }
 
 .shared-header-skeleton {
-  background-color: $cr-cyan;
+  background-color: $cr-blue;
 
   .shared-header-skeleton-logo {
     left: 50%;


### PR DESCRIPTION
Sets the shared header skeleton to use `$cr-blue` to match header background change in [CRDS Components PR](https://github.com/crdschurch/crds-components/pull/549)