### PR TITLE
US19542 Primary Link 

### DIFF
--- a/assets/stylesheets/_overrides.scss
+++ b/assets/stylesheets/_overrides.scss
@@ -17,8 +17,8 @@ $gray-lighter: $cr-gray-lighter !default;
 // Scaffolding
 $body-bg: $cr-white !default;
 $text-color: $cr-gray-dark !default;
-$link-color: $cr-cyan !default;
-$link-hover-color: $cr-cyan-dark !default;
+$link-color: $cr-orange-dark !default;
+$link-hover-color: $cr-orange !default;
 $link-hover-decoration: underline;
 
 // Typography

--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -16,7 +16,7 @@ $cr-blue-lighter: rgba(219, 228, 234, 1);
 
 // Orange
 $cr-orange: rgba(255, 130, 0, 1); // #FF8200
-$cr-orange-dark: $cr-orange;
+$cr-orange-dark: rgb(187, 73, 0); // #BB4900
 $cr-orange-light: $cr-orange;
 $cr-orange-lighter: $cr-orange;
 

--- a/assets/stylesheets/utilities/_colors.scss
+++ b/assets/stylesheets/utilities/_colors.scss
@@ -25,5 +25,5 @@
 }
 
 .text-orange {
-  color: $cr-orange;
+  color: $cr-orange-dark;
 }


### PR DESCRIPTION
Specify primary link color and text-orange as darker orange. Note– the text-orange update is kind of unrelated to US19542 but I discussed with @amplerob and he suggested that we maintain consistency for any orange text, primarily due to the contrast ratio for the lighter orange (see screenshot below for the inconsistency that is being resolved here.

#### Related PRs: 

crdschurch/crds-media#905

---

![Media](https://user-images.githubusercontent.com/50378/81963581-453d9500-95e3-11ea-8066-f6b37e407edb.png)
