### PR TITLE
US19549 Card Font Weight

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -93,7 +93,7 @@
 .card-title {
   color: $cr-gray-dark;
   line-height: 1;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .card-title--overlap {


### PR DESCRIPTION
## Task
Some cards have different font-weights for titles
[Rally Story](https://rally1.rallydev.com/#/38108142417d/detail/userstory/391433091768?fdp=true)

## Solution
Change font-weight to 500 to create consistency for all media cards
![Screen Shot 2020-05-15 at 10 54 48 AM](https://user-images.githubusercontent.com/32345656/82064465-cdcb3c80-969a-11ea-9130-b32d3c6704e2.png)
