### PR TITLE
Adds rebrand styles to /live

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -141,9 +141,9 @@
   position: relative;
 
   .img-caption {
-    background-color: $cr-blue-lighter;
+    background-color: $cr-orange;
     bottom: -1rem;
-    color: $cr-gray-dark;
+    color: $cr-blue;
     font-family: $accent-font-face;
     font-size: 0.8125rem;
     font-style: italic;

--- a/assets/stylesheets/components/_countdown.scss
+++ b/assets/stylesheets/components/_countdown.scss
@@ -73,6 +73,19 @@
 }
 
 /* 3. Color Variations */
+.countdown-bg-orange { 
+  background-color: $cr-orange; 
+  
+  .countdown-btn { 
+    background-color: $cr-blue; 
+    color: $cr-white;
+
+    &:hover { 
+      background-color: lighten($cr-blue, 5); 
+    }
+  }
+}
+
 .countdown-bg-cyan {
   background-color: $cr-cyan;
 

--- a/assets/stylesheets/utilities/_backgrounds.scss
+++ b/assets/stylesheets/utilities/_backgrounds.scss
@@ -6,6 +6,10 @@
   @include crds-bg-variant($brand-info);
 }
 
+.bg-social {
+  @include crds-bg-variant($cr-orange);
+}
+
 .bg-warning {
   @include crds-bg-variant($brand-warning);
 }


### PR DESCRIPTION
## Problem
Change button color for onsite group details page to match rebrand criteria (orange button/ blue text)

[CRDS-NET](https://github.com/crdschurch/crds-net/pull/1490)
[Rally](https://rally1.rallydev.com/#/66096747656ud/discussion?previousTokens=%2F66096747656ud%2Fcustom%2F24109743995%3Fqdp%3D%252Fdetail%252Fuserstory%252F393973364824&qdp=%2Fdetail%2Fuserstory%2F393973364824&ref=%2Fhierarchicalrequirement%2F393973364824)

## Solution
Created orange button with blue text and implemented style to on-site groups details page.

## Testing
Run crds-net locally, and navigate to any on-site groups details page.
Example url - /groups/onsite/COME-AS-YOU-ARE-FLORENCE-2019/columbus/