### PR TITLE
US19581 Reachout Go

### DIFF
--- a/assets/stylesheets/components/_jumbotrons.scss
+++ b/assets/stylesheets/components/_jumbotrons.scss
@@ -14,7 +14,6 @@
 
     a {
       display: inline-block;
-      color: $cr-white;
     }
   }
 


### PR DESCRIPTION
## Problem
Update reachout/go page for rebrand
[Design here](https://www.dropbox.com/s/h9fmgeoq9fxwbgm/rebrand_crossroads_net_reachout_go___2_.jpg?dl=0)
[Rally Story](https://rally1.rallydev.com/#/detail/userstory/394024759516?fdp=true)

## Solution
Page is updated in contentful.
Deleted style where it was making every link color inside of classes `.jumbotron` and `.bg-video` white

## Corresponding PR
[Crds-Net](https://github.com/crdschurch/crds-net/pull/1497)