### PR TITLE
US19552 - Adds a button for rollcall that has a white background and new cr-blu…

### DIFF
--- a/assets/stylesheets/_overrides.scss
+++ b/assets/stylesheets/_overrides.scss
@@ -102,6 +102,9 @@ $btn-gray-lt-color: $cr-white;
 $btn-white-bg: $cr-white;
 $btn-white-border: $cr-white;
 $btn-white-color: $cr-gray-dark;
+$btn-white-blue-bg: $cr-white;
+$btn-white-blue-border: $cr-white;
+$btn-white-blue-color: $cr-blue;
 
 // $btn-warning-color: !default;
 // $btn-warning-bg: !default;

--- a/assets/stylesheets/components/buttons/_buttons.scss
+++ b/assets/stylesheets/components/buttons/_buttons.scss
@@ -82,6 +82,14 @@
     );
   }
 
+  &.btn-white-blue { 
+    @include crds-button-variant(
+      $btn-white-blue-bg,
+      $btn-white-blue-border,
+      $btn-white-blue-color,
+    );
+  }
+
   &.btn-white {
     background: $btn-white-bg;
     border-color: $btn-white-border;


### PR DESCRIPTION
## Task 
Rebrand rollcall requires increase, decrease, and location buttons with `$cr-white` background and `$cr-blue` text/icons. (See screenshot) 

![rebrand rollcall](https://user-images.githubusercontent.com/57996315/83058278-1df4b800-a026-11ea-8e8b-675677fb3d98.png)
