### PR TITLE
US19623/Adds rebrand styles to latest message

### DIFF
--- a/assets/stylesheets/components/_latest-message.scss
+++ b/assets/stylesheets/components/_latest-message.scss
@@ -1,10 +1,9 @@
 .background-tan {
-    background-color: #E7E2D0;
-    max-width: 765px; 
+    background-color: $cr-tan-lighter;
 }
 
 .body-gray {
-    color: #5f5f5f;
+    color: $cr-gray-lighter;
     font-size: 19px; 
     letter-spacing: 0;
     max-width: 750px; 
@@ -32,7 +31,7 @@
 }
 
 .headline-gray {
-    color: #575757;
+    color: $cr-gray-lighter;
     font-size: 52px;
     margin-top: 18px; 
 }
@@ -42,13 +41,13 @@
 }
 
 .subtitle-gray {
-    color: #999;
+    color: $cr-gray-lighter;
     font-size: 12px;
     margin-top: 0px; 
     margin-bottom: 20px; 
 }
 
 .title { 
-    color: #808080; 
+    color: $cr-gray-light; 
     font-size: 15px; 
 }

--- a/assets/stylesheets/components/_latest-message.scss
+++ b/assets/stylesheets/components/_latest-message.scss
@@ -1,0 +1,35 @@
+.background-tan {
+    background-color: #E7E2D0;
+}
+
+.body-gray {
+    color: #5f5f5f;
+    font-size: 19px; 
+    letter-spacing: 0;
+    max-width: 750px; 
+}
+
+.btn { 
+    border-radius: 0; 
+}
+
+.headline-gray {
+    color: #575757;
+    font-size: 52px;
+    margin-top: 18px; 
+}
+
+.second-btn { 
+    margin-left: 14.5px; 
+}
+
+.subtitle-gray {
+    color: #999;
+    font-size: 12px;
+    margin-top: 0px; 
+}
+
+.title { 
+    color: #808080; 
+    font-size: 15px; 
+}

--- a/assets/stylesheets/components/_latest-message.scss
+++ b/assets/stylesheets/components/_latest-message.scss
@@ -13,6 +13,22 @@
     border-radius: 0; 
 }
 
+.embed-container { 
+    position: relative; 
+    padding-bottom: 56.25%; 
+    height: 0; 
+    overflow: hidden; 
+    max-width: 100%; 
+} 
+
+.embed-container iframe, .embed-container object, .embed-container embed { 
+    position: absolute; 
+    top: 0; 
+    left: 0; 
+    width: 100%; 
+    height: 100%; 
+}
+
 .headline-gray {
     color: #575757;
     font-size: 52px;

--- a/assets/stylesheets/components/_latest-message.scss
+++ b/assets/stylesheets/components/_latest-message.scss
@@ -1,5 +1,6 @@
 .background-tan {
     background-color: #E7E2D0;
+    max-width: 765px; 
 }
 
 .body-gray {
@@ -7,6 +8,7 @@
     font-size: 19px; 
     letter-spacing: 0;
     max-width: 750px; 
+    margin-bottom: 20px; 
 }
 
 .btn { 
@@ -43,6 +45,7 @@
     color: #999;
     font-size: 12px;
     margin-top: 0px; 
+    margin-bottom: 20px; 
 }
 
 .title { 


### PR DESCRIPTION
## Task 
Adds correct font colors per rebrand design. 
[Design ](https://projects.invisionapp.com/d/main/#/console/19749433/418123067/preview)
[Rally ](https://rally1.rallydev.com/#/66096747656ud/detail/userstory/395256033436?fdp=true)

## Notes 
Per Rob, 
**#999999 and #575757 are to be switched to $cr-gray-lighter and #808080 is to be switched to $cr-gray-light.** 

Colors were matched per invision design. 
