### PR TITLE
Adds correct variables and styles for content menu

### DIFF
--- a/assets/stylesheets/components/_content-menu.scss
+++ b/assets/stylesheets/components/_content-menu.scss
@@ -9,7 +9,6 @@
 }
 
 .content-menu-link { 
-  font-weight: 600px!important; 
   position: relative; 
   top: 28px; 
 }

--- a/assets/stylesheets/components/_content-menu.scss
+++ b/assets/stylesheets/components/_content-menu.scss
@@ -1,29 +1,29 @@
-.content-menu { 
-  background-color: $cr-tan-light; 
-  border: 1px solid $cr-gray-lighter; 
-  height: auto; 
+.content-menu {
+  background-color: $cr-tan-light;
+  border: 1px solid $cr-gray-lighter;
+  height: auto;
   background-color: $cr-tan-light;
   margin-left: 10px;
-  padding: 10px 0px 20px; 
-  position: relative; 
-  top: 0px; 
+  padding: 10px 0px 20px;
+  position: relative;
+  top: 0px;
 }
 
-.content-menu-link { 
-  position: relative; 
-  top: 28px; 
+.content-menu-link {
+  position: relative;
+  top: 28px;
 }
 
-.content-menu-list { 
-  padding: 20px 0px; 
+.content-menu-list {
+  padding: 20px 0px;
 
-  &:first-child { 
+  &:first-child {
     position: absolute;
     top: 5px;
   }
 }
-  
-.content-menu-title { 
+
+.content-menu-title {
   position: relative;
   top: 4px;
   padding-bottom: 10px;

--- a/assets/stylesheets/components/_content-menu.scss
+++ b/assets/stylesheets/components/_content-menu.scss
@@ -1,17 +1,30 @@
 .content-menu { 
-  background-color: $cr-tan-lighter; 
+  background-color: $cr-tan-light; 
   border: 1px solid $cr-gray-lighter; 
-  height: auto; 
+  height: 100%; 
   margin-left: 10px;
-  padding-top: 10px; 
+  padding: 10px 0px 20px; 
+  position: relative; 
+  top: 0px; 
+}
 
-  .menu-link { 
-    position: relative; 
-    top: 4px; 
+.content-menu-link { 
+  font-weight: 600px!important; 
+  position: relative; 
+  top: 28px; 
+}
+
+.content-menu-list { 
+  padding: 20px 0px; 
+
+  &:first-child { 
+    position: absolute;
+    top: 5px;
   }
+}
   
-  .menu-title { 
-    position: relative;
-    top: 4px;
-  }
+.content-menu-title { 
+  position: relative;
+  top: 4px;
+  padding-bottom: 10px;
 }


### PR DESCRIPTION
## Problem 

crds-styles submodule was not correctly reflecting updates to the development branch, and causing concerns with building locally. Updated _variables.scss and _modules.scss and updated styles. Per AG - Media link has been removed. 

## Task 
Adds Explore Our Content menu per homepage rebrand. 

[Rally](https://rally1.rallydev.com/#/66096747656ud/detail/userstory/395842984940?fdp=true)

## Notes 
#F5F5F5 is substituted to $cr-gray-lighter
<img width="377" alt="Screen Shot 2020-06-02 at 12 31 46 PM" src="https://user-images.githubusercontent.com/57996315/83676041-0aa69700-a5a8-11ea-9fd8-b6e82dd1fdd7.png">
