### PR TITLE
DE7785/Expands links clickable area on our content menu

### DIFF
--- a/assets/stylesheets/components/_content-menu.scss
+++ b/assets/stylesheets/components/_content-menu.scss
@@ -4,11 +4,16 @@
   height: auto;
   margin-left: 10px;
   padding: 10px 0px 20px;
-}
 
-.content-menu-link {
-  position: relative;
-  top: 28px;
+  a {
+    display: inline-block;    
+    height: 100%;  
+    position: relative;    
+    z-index: 1;     
+    padding: 0 2em 0 0;     
+    top: 28px;
+    width: 100%;
+  }
 }
 
 .content-menu-list {


### PR DESCRIPTION
## Problem 

Links were only clickable above the anchor tag. 
[Rally](https://rally1.rallydev.com/#/38108142417d/detail/defect/398132680380?fdp=true)

## Solution 

Styles anchor tag directly instead of utilizing an inline class. 