### PR TITLE
Resolves clickable area on content menu

### DIFF
--- a/assets/stylesheets/components/_content-menu.scss
+++ b/assets/stylesheets/components/_content-menu.scss
@@ -6,18 +6,17 @@
   padding: 10px 0px 20px;
 
   a {
-    display: inline-block;    
+    box-sizing: content-box; 
+    display: block;    
     height: 100%;  
-    position: relative;    
-    z-index: 1;     
-    padding: 0 2em 0 0;     
-    top: 28px;
+    padding: 20px 0px;   
     width: 100%;
+    z-index: 1; 
   }
 }
 
 .content-menu-list {
-  padding: 20px 0px;
+  padding-bottom: 10px; 
 
   &:first-child {
     padding-top: 0px;


### PR DESCRIPTION
## Problem
Anchor tags on content menu were only clickable above the link. 

[Rally ](https://rally1.rallydev.com/#/38108142417d/detail/defect/398132680380/discussion)

## Solution
Styles anchor tags directly and removes unused classes. 