### PR TITLE
DE7804 [rebrand] a few more about pg updates

### DIFF
--- a/assets/stylesheets/components/_typography.scss
+++ b/assets/stylesheets/components/_typography.scss
@@ -180,15 +180,18 @@
   font-size: $font-size-h1;
   font-weight: bold;
   letter-spacing: 4px;
-  padding: 30px 50px;
+  padding: 30px 15px;
   text-align: center;
   text-transform: uppercase;
+
+  @media screen and (min-width: $screen-xs) {
+    padding: 30px 50px;
+  }
 
   &.component-header-box-border-lg {
     border-width: 6px;
   }
 }
-
 
 .title {
   font-family: $base-font-face;


### PR DESCRIPTION
This PR reduces `.component-header-box` horizontal padding on mobile. This resolves the 4th item on the defect in [Rally](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?qdp=%2Fdetail%2Fdefect%2F398975289204)

> The header block for the FAQs looks bunk on mobile (Safari, iOS)(screenshot)

## Related PR

- [crds-net](https://github.com/crdschurch/crds-net/pull/1581)