### PR TITLE
DE7833 Media Image Overlay

### DIFF
--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -68,7 +68,7 @@
   background-image: linear-gradient(
     to bottom,
     rgba(23, 23, 23, 0),
-    $cr-gray-darker
+    $cr-black
   );
 }
 


### PR DESCRIPTION
## Problem 
Fix `bg-overlay` to fade from black instead of gray-darker

## Corresponding PRs
These PRs delete unneeded styles for `bg-overlay` since it is already defined in this repo
[Crds-Net](https://github.com/crdschurch/crds-net/pull/1608)
[Crds-Meida](https://github.com/crdschurch/crds-media/pull/942)