### PR TITLE
DE7845/Media Color Corrections

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -239,6 +239,7 @@
 }
 
 .card-stamp {
+  background: $cr-black;
   position: absolute;
   right: 0;
   bottom: 0;

--- a/assets/stylesheets/components/_tabs.scss
+++ b/assets/stylesheets/components/_tabs.scss
@@ -117,7 +117,7 @@
 }
 
 .sidebar-nav-trigger {
-  background-color: $cr-gray-lighter;
+  background-color: $cr-white;
   border: 1px solid #CACACA;
   display: block;
   line-height: 1;


### PR DESCRIPTION
## Task 
Change all media time stamp icons background to $cr-black. 
Change search bar navigation on mobile view background to $cr-white. 

[Rally ](https://rally1.rallydev.com/#/66096747656ud/detail/defect/399897009888?fdp=true)