### PR TITLE
DE7874: [rebrand] if alert bar is showing on /live, the stream bar gets covered up on scroll 

### DIFF
--- a/assets/stylesheets/utilities/_utilities.scss
+++ b/assets/stylesheets/utilities/_utilities.scss
@@ -810,6 +810,10 @@ a.underline,
   position: sticky;
   top: 48px;
   z-index: 3;
+
+  .header-notification-open & {
+    top: 94px;
+  }
 }
 
 


### PR DESCRIPTION
Adjusts the `top` on `.stick-below-header` for when the `<crds-shared-header />` notification is open. This helps to solve the Live bar going behind the menu (also any other place where `.stick-below-header` is used)

[Rally Story](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?qdp=%2Fdetail%2Fdefect%2F400313140820)

## Related PRs

- [crds-components](https://github.com/crdschurch/crds-components/pull/703)
- [crds-net](https://github.com/crdschurch/crds-net/pull/1641)