### PR TITLE
US20614 Webfont Visibility

### DIFF
--- a/assets/stylesheets/base/_fonts.scss
+++ b/assets/stylesheets/base/_fonts.scss
@@ -11,6 +11,7 @@ $fontUrl: '//d1tmclqz61gqwd.cloudfront.net/fonts/';
     url('#{$fontUrl}SentinelSSm-BookWeb.woff2') format('woff2'); /* Modern Browsers */
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -24,4 +25,5 @@ $fontUrl: '//d1tmclqz61gqwd.cloudfront.net/fonts/';
     url('#{$fontUrl}SentinelSSm-BookItalicWeb.woff2') format('woff2'); /* Modern Browsers */
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }


### PR DESCRIPTION
## Problem
[Rally Task](https://rally1.rallydev.com/#/66096747656d/custom/24109743995?detail=%2Fuserstory%2F492689707936)

## Solution
Change `font-display` to `swap` to keep system fonts visible while webfonts load.

### Corresponding Branch
Most of the work for this done in the `crds-net` repo. See this PR:
https://github.com/crdschurch/crds-net/pull/2368

## Testing
Run a Lighthouse Performance test on any page. The warning "Ensure text remains visible during webfont load" in the `Diagnostics` section should not include the font called `BookWeb`.

