### PR TITLE
updating bg-topo bg-image

### DIFF
--- a/assets/stylesheets/utilities/_backgrounds.scss
+++ b/assets/stylesheets/utilities/_backgrounds.scss
@@ -91,7 +91,7 @@
 }
 
 .bg-topo {
-  background-image: url('//crds-media.imgix.net/1KLwsN6ilL7RO0xk6JzOsX/840e8b99340ff36bff67036909c4f856/texture-topo-dark-100_2x.png');
+  background-image: url('//crds-media.imgix.net/4KelidUTZORxCURuMjpyMf/b24f68ba291849a6fa8f92596c0224d0/texture-topo-dark-100_2x.png');
 }
 
 .bg-topo-50 {


### PR DESCRIPTION
Fixing the missing image on /groups /about. 
It's the class: bg-topo